### PR TITLE
add high priority and cleanup formatting of data maps

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -32,9 +32,20 @@ func (me *AndroidNotificationServer) Initialize() bool {
 func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) PushResponse {
 	var data map[string]interface{}
 	if msg.Type == PUSH_TYPE_CLEAR {
-		data = map[string]interface{}{"type": PUSH_TYPE_CLEAR, "channel_id": msg.ChannelId, "team_id": msg.TeamId}
+		data = map[string]interface{}{
+			"type":       PUSH_TYPE_CLEAR,
+			"channel_id": msg.ChannelId,
+			"team_id":    msg.TeamId,
+		}
 	} else {
-		data = map[string]interface{}{"type": PUSH_TYPE_MESSAGE, "message": emoji.Sprint(msg.Message), "channel_id": msg.ChannelId, "channel_name": msg.ChannelName, "team_id": msg.TeamId}
+		data = map[string]interface{}{
+			"type":         PUSH_TYPE_MESSAGE,
+			"message":      emoji.Sprint(msg.Message),
+			"channel_id":   msg.ChannelId,
+			"channel_name": msg.ChannelName,
+			"team_id":      msg.TeamId,
+			"priority":     "high",
+		}
 	}
 
 	regIDs := []string{msg.DeviceId}


### PR DESCRIPTION
After some testing on with the GCM library, push notifications weren't working without the priority setting. 

Multiple users were reporting issues of long delays or no push notifications sent in production, this seems related.

reference: https://developers.google.com/cloud-messaging/http-server-ref