### PR TITLE
Use stdlib `http.Error` to handle failed requests

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/tylerb/graceful"
-	"gopkg.in/throttled/throttled.v1"
 	throttledStore "gopkg.in/throttled/throttled.v1/store"
 )
 
@@ -103,19 +102,19 @@ func handleSendNotification(w http.ResponseWriter, r *http.Request) {
 
 	if msg == nil {
 		rMsg := LogError("Failed to read message body")
-		w.Write([]byte(rMsg.ToJson()))
+		http.Error(w, rMsg.ToJson(), http.StatusBadRequest)
 		return
 	}
 
 	if len(msg.ServerId) == 0 {
 		rMsg := LogError("Failed because of missing server Id")
-		w.Write([]byte(rMsg.ToJson()))
+		http.Error(w, rMsg.ToJson(), http.StatusBadRequest)
 		return
 	}
 
 	if len(msg.DeviceId) == 0 {
 		rMsg := LogError(fmt.Sprintf("Failed because of missing device Id serverId=%v", msg.ServerId))
-		w.Write([]byte(rMsg.ToJson()))
+		http.Error(w, rMsg.ToJson(), http.StatusBadRequest)
 		return
 	}
 
@@ -129,7 +128,7 @@ func handleSendNotification(w http.ResponseWriter, r *http.Request) {
 		return
 	} else {
 		rMsg := LogError(fmt.Sprintf("Did not send message because of missing platform property type=%v serverId=%v", msg.Platform, msg.ServerId))
-		w.Write([]byte(rMsg.ToJson()))
+		http.Error(w, rMsg.ToJson(), http.StatusInternalServerError)
 		return
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/tylerb/graceful"
+	"gopkg.in/throttled/throttled.v1"
 	throttledStore "gopkg.in/throttled/throttled.v1/store"
 )
 


### PR DESCRIPTION
Explicitly claims error func to improve readability.