### PR TITLE
Add a unified http_client

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -60,7 +60,10 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	regIDs := []string{msg.DeviceId}
 	gcmMsg := gcm.NewMessage(data, regIDs...)
 
-	sender := &gcm.Sender{ApiKey: me.AndroidPushSettings.AndroidApiKey}
+	sender := &gcm.Sender{
+		ApiKey: me.AndroidPushSettings.AndroidApiKey,
+		Http:   httpClient,
+	}
 
 	if len(me.AndroidPushSettings.AndroidApiKey) > 0 {
 		LogInfo(fmt.Sprintf("Sending android push notification for type=%v", me.AndroidPushSettings.Type))

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -40,9 +40,6 @@ var httpClient = &http.Client{
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   TLSDialTimeout,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: enableInsecureConnections,
-		},
 	},
 	Timeout: HTTPClientTimeout,
 }

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -4,8 +4,12 @@
 package server
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"io"
+	"net"
+	"net/http"
+	"time"
 )
 
 const (
@@ -13,7 +17,35 @@ const (
 	PUSH_NOTIFY_ANDROID = "android"
 	PUSH_TYPE_MESSAGE   = "message"
 	PUSH_TYPE_CLEAR     = "clear"
+
+	// TLSDialTimeout is the maximum amount of time a dial will wait for a connect
+	// to complete.
+	TLSDialTimeout = 20 * time.Second
+
+	// HTTPClientTimeout specifies a time limit for requests made by the
+	// HTTPClient. The timeout includes connection time, any redirects,
+	// and reading the response body.
+	HTTPClientTimeout = 30 * time.Second
 )
+
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   TLSDialTimeout,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   TLSDialTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: enableInsecureConnections,
+		},
+	},
+	Timeout: HTTPClientTimeout,
+}
 
 type PushNotification struct {
 	Platform         string `json:"platform"`


### PR DESCRIPTION
- Replace default global http_client in stdlib, w/ timeout/proxy settings, etc
- Use the http_client to send push messages to GCM
- Haven't found how to set httpClient in the APNs library, so don't make changes