### PR TITLE
Use aps thread-id to group notifications from the same channel in iOS12

### DIFF
--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -78,6 +78,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 
 	if len(msg.ChannelId) > 0 {
 		payload.Custom("channel_id", msg.ChannelId)
+		payload.ThreadID(msg.ChannelId)
 	}
 
 	if len(msg.TeamId) > 0 {


### PR DESCRIPTION
After this is deployed users with iOS 12 will group their notifications based on channels

Meaning:
received 3 messages from channel A and 2 messages from channel B user will see two stacks of push notifications, one stack with 3 messages corresponding to channel A and another stack with 2 messages corresponding to channel B.

Feel free to deploy this at any time