### PR TITLE
Fix "notificaiton" typos in README, Android server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For organizations who want to keep internal communications behind their firewall
 
 ### Obtaining Apple Developer Keys
 
-For more in-depth instructions on setting up push notificaitons with your own build please follow the directions at [docs.mattermost.com](https://docs.mattermost.com/developer/mobile-developer-setup.html#push-notifications-with-your-own-build)
+For more in-depth instructions on setting up push notifications with your own build please follow the directions at [docs.mattermost.com](https://docs.mattermost.com/developer/mobile-developer-setup.html#push-notifications-with-your-own-build)
 
 1. Follow the directions at [developer.apple.com](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/DistributingEnterpriseProgramApps/DistributingEnterpriseProgramApps.html#//apple_ref/doc/uid/TP40012582-CH33-SW4) to generate an Apple Push Notification service SSL Certificate, this should give you an `aps_production.cer`
 2. Convert the certificate format to .pem:

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -20,7 +20,7 @@ func NewAndroideNotificationServer(settings AndroidPushSettings) NotificationSer
 }
 
 func (me *AndroidNotificationServer) Initialize() bool {
-	LogInfo(fmt.Sprintf("Initializing Android notificaiton server for type=%v", me.AndroidPushSettings.Type))
+	LogInfo(fmt.Sprintf("Initializing Android notification server for type=%v", me.AndroidPushSettings.Type))
 
 	if len(me.AndroidPushSettings.AndroidApiKey) == 0 {
 		LogError("Android push notifications not configured.  Missing AndroidApiKey.")


### PR DESCRIPTION
Replace "notificaiton" with the proper spelling: "notification". This closes [issue #9660](https://github.com/mattermost/mattermost-server/issues/9660).