### PR TITLE
Send content-available with clear notification

### DIFF
--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -72,6 +72,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 		}
 	} else {
 		payload.Alert("")
+		payload.ContentAvailable()
 	}
 
 	payload.Custom("type", msg.Type)


### PR DESCRIPTION
By sending the content-available with the notification, the app can process the notification in the background more info [here](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW8)

Note: If the app is closed there is no way to process the notification meaning that the previous notifications in the NotificationCenter won't be cleared