### PR TITLE
MM-14292 remove alert from clear notification payload

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"fmt"
-	"github.com/mattermost/mattermost-push-proxy/vendor/github.com/appleboy/go-fcm"
 	"time"
 
 	"github.com/appleboy/go-fcm"

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"fmt"
+	"github.com/mattermost/mattermost-push-proxy/vendor/github.com/appleboy/go-fcm"
 	"time"
 
 	"github.com/appleboy/go-fcm"
@@ -73,7 +74,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 			return NewErrorPushResponse(err.Error())
 		}
 
-		LogInfo(fmt.Sprintf("Sending android push notification for type=%v", me.AndroidPushSettings.Type))
+		LogInfo(fmt.Sprintf("Sending android push notification for device=%v and type=%v", me.AndroidPushSettings.Type, msg.Type))
 		start := time.Now()
 		resp, err := sender.SendWithRetry(fcmMsg, 2)
 		observeFCMResponse(time.Since(start).Seconds())

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -58,6 +58,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 		payload.Category(msg.Category)
 		payload.Sound("default")
 		payload.Custom("version", msg.Version)
+		payload.MutableContent()
 
 		if len(msg.ChannelName) > 0 && msg.Version == "v2" {
 			payload.AlertTitle(msg.ChannelName)

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -110,7 +110,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	}
 
 	if me.AppleClient != nil {
-		LogInfo(fmt.Sprintf("Sending apple push notification type=%v", me.ApplePushSettings.Type))
+		LogInfo(fmt.Sprintf("Sending apple push notification for device=%v and type=%v", me.ApplePushSettings.Type, msg.Type))
 		start := time.Now()
 		res, err := me.AppleClient.Push(notification)
 		observeAPNSResponse(time.Since(start).Seconds())

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -71,7 +71,6 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 			}
 		}
 	} else {
-		payload.Alert("")
 		payload.ContentAvailable()
 	}
 


### PR DESCRIPTION
iOS won't show notifications that do not have an alert in the body BUT in order for the OS to detect that this is in fact a "silent notification" we need to remove the alert from the payload completely, this will ensure that even if the app is fully closed the app will be able to process the clear notification.

The allow mutation piece is for further improvements so we can use a **Notification Extension** to use the upcoming ack endpoint for the receipt delivery.

@cpanato feel free to merge this once reviewed and build a release. it can be 5.9.0