### PR TITLE
Set FCM notifications as High priority

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -63,8 +63,9 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	}
 
 	fcmMsg := &fcm.Message{
-		To:   msg.DeviceId,
-		Data: data,
+		To:       msg.DeviceId,
+		Data:     data,
+		Priority: "high",
 	}
 
 	if len(me.AndroidPushSettings.AndroidApiKey) > 0 {


### PR DESCRIPTION
This will show the push notification on Android even if the device is in doze mode.