### PR TITLE
MM-18463 Add handling for update_badge notifications

### DIFF
--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -56,7 +56,8 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Topic = me.ApplePushSettings.ApplePushTopic
 
 	var pushType = msg.Type
-	if msg.Type != PUSH_TYPE_CLEAR {
+	switch msg.Type {
+	case PUSH_TYPE_MESSAGE:
 		pushType = PUSH_TYPE_MESSAGE
 		data.Category(msg.Category)
 		data.Sound("default")
@@ -74,8 +75,10 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 				data.Custom("channel_name", msg.ChannelName)
 			}
 		}
-	} else {
+	case PUSH_TYPE_CLEAR:
 		data.ContentAvailable()
+	case PUSH_TYPE_UPDATE_BADGE:
+		// Handled by the apps, nothing else to do here
 	}
 
 	incrementNotificationTotal(PUSH_NOTIFY_APPLE, pushType)

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -11,8 +11,14 @@ import (
 const (
 	PUSH_NOTIFY_APPLE   = "apple"
 	PUSH_NOTIFY_ANDROID = "android"
-	PUSH_TYPE_MESSAGE   = "message"
-	PUSH_TYPE_CLEAR     = "clear"
+
+	PUSH_TYPE_MESSAGE      = "message"
+	PUSH_TYPE_CLEAR        = "clear"
+	PUSH_TYPE_UPDATE_BADGE = "update_badge"
+
+	PUSH_MESSAGE_V2 = "v2"
+
+	PUSH_SOUND_NONE = "none"
 )
 
 type PushNotificationAck struct {


### PR DESCRIPTION
The `update_badge` notification contains almost all of the information needed by the app to set the app's badge, but the previous code caused the `sound` flag to be set for the notification, so it would play a sound effect on iOS without displaying a notification

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18463