### PR TITLE
[MM-16232] Support ID loaded push notifications

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -42,6 +42,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 
 	if pushType == PUSH_TYPE_ID_LOADED {
 		data["post_id"] = msg.PostId
+		data["message"] = msg.Message
 	} else if pushType == PUSH_TYPE_MESSAGE {
 		data["team_id"] = msg.TeamId
 		data["sender_id"] = msg.SenderId

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -41,13 +41,9 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 
 	if pushType == PUSH_TYPE_ID_LOADED {
 		data["post_id"] = msg.PostId
-	}
-
-	if pushType == PUSH_TYPE_CLEAR {
+	} else if pushType == PUSH_TYPE_CLEAR {
 		data["channel_id"] = msg.ChannelId
-	}
-
-	if pushType == PUSH_TYPE_MESSAGE {
+	} else if pushType == PUSH_TYPE_MESSAGE {
 		data["channel_id"] = msg.ChannelId
 		data["team_id"] = msg.TeamId
 		data["sender_id"] = msg.SenderId

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -33,17 +33,25 @@ func (me *AndroidNotificationServer) Initialize() bool {
 func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) PushResponse {
 	pushType := msg.Type
 	data := map[string]interface{}{
-		"ack_id":      msg.AckId,
-		"type":        pushType,
-		"badge":       msg.Badge,
-		"channel_id":  msg.ChannelId,
-		"team_id":     msg.TeamId,
-		"sender_id":   msg.SenderId,
-		"sender_name": msg.SenderName,
-		"version":     msg.Version,
+		"ack_id":  msg.AckId,
+		"type":    pushType,
+		"badge":   msg.Badge,
+		"version": msg.Version,
+	}
+
+	if pushType == PUSH_TYPE_ID_LOADED {
+		data["post_id"] = msg.PostId
+	}
+
+	if pushType == PUSH_TYPE_CLEAR {
+		data["channel_id"] = msg.ChannelId
 	}
 
 	if pushType == PUSH_TYPE_MESSAGE {
+		data["channel_id"] = msg.ChannelId
+		data["team_id"] = msg.TeamId
+		data["sender_id"] = msg.SenderId
+		data["sender_name"] = msg.SenderName
 		data["message"] = emoji.Sprint(msg.Message)
 		data["channel_name"] = msg.ChannelName
 		data["post_id"] = msg.PostId

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -33,18 +33,16 @@ func (me *AndroidNotificationServer) Initialize() bool {
 func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) PushResponse {
 	pushType := msg.Type
 	data := map[string]interface{}{
-		"ack_id":  msg.AckId,
-		"type":    pushType,
-		"badge":   msg.Badge,
-		"version": msg.Version,
+		"ack_id":     msg.AckId,
+		"type":       pushType,
+		"badge":      msg.Badge,
+		"version":    msg.Version,
+		"channel_id": msg.ChannelId,
 	}
 
 	if pushType == PUSH_TYPE_ID_LOADED {
 		data["post_id"] = msg.PostId
-	} else if pushType == PUSH_TYPE_CLEAR {
-		data["channel_id"] = msg.ChannelId
 	} else if pushType == PUSH_TYPE_MESSAGE {
-		data["channel_id"] = msg.ChannelId
 		data["team_id"] = msg.TeamId
 		data["sender_id"] = msg.SenderId
 		data["sender_name"] = msg.SenderName

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -57,6 +57,8 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 
 	var pushType = msg.Type
 	switch msg.Type {
+	case PUSH_TYPE_ID_LOADED:
+		data.MutableContent()
 	case PUSH_TYPE_MESSAGE:
 		pushType = PUSH_TYPE_MESSAGE
 		data.Category(msg.Category)

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -62,6 +62,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 		data.Sound("default")
 		data.Custom("version", msg.Version)
 		data.MutableContent()
+		data.AlertBody(msg.Message)
 	case PUSH_TYPE_MESSAGE:
 		data.Category(msg.Category)
 		data.Sound("default")

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -58,9 +58,11 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	var pushType = msg.Type
 	switch msg.Type {
 	case PUSH_TYPE_ID_LOADED:
+		data.Category(msg.Category)
+		data.Sound("default")
+		data.Custom("version", msg.Version)
 		data.MutableContent()
 	case PUSH_TYPE_MESSAGE:
-		pushType = PUSH_TYPE_MESSAGE
 		data.Category(msg.Category)
 		data.Sound("default")
 		data.Custom("version", msg.Version)

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -12,6 +12,7 @@ const (
 	PUSH_NOTIFY_APPLE   = "apple"
 	PUSH_NOTIFY_ANDROID = "android"
 
+	PUSH_TYPE_ID_LOADED    = "id_loaded"
 	PUSH_TYPE_MESSAGE      = "message"
 	PUSH_TYPE_CLEAR        = "clear"
 	PUSH_TYPE_UPDATE_BADGE = "update_badge"


### PR DESCRIPTION
Added a new `PUSH_TYPE_ID_LOADED` type and updated the Android and Apple notification servers to handle ID loaded push notifications.