### PR TITLE
MM-24316: Cleanup Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,7 @@
 
 logs
 .DS_Store
-node_modules
 dist
-npm-debug.log
-
-web/static/js/bundle*.js
-web/static/js/bundle*.js.map
-web/static/js/libs*.js
 
 # Build Targets
 .prebuild
@@ -26,12 +20,6 @@ _test
 # Architecture specific extensions/prefixes
 [568vq].out
 
-*.cgo1.go
-*.cgo2.c
-_cgo_defun.c
-_cgo_gotypes.go
-_cgo_export.*
-
 _testmain.go
 
 *.exe
@@ -40,18 +28,9 @@ _testmain.go
 
 # Log files
 *mattermost.log
-*npm-debug.log*
 
 # Vim temporary files
 *.swp
-
-# Build files
-*bundle.js
-
-web/sass-files/sass/.sass-cache/
-*config.codekit
-*.sass-cache
-*styles.css
 
 # Default local file storage
 data/*

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
 .PHONY: all dist build-server package test clean run update-dependencies gofmt govet check-style
 
-GOPATH ?= $(HOME)/go
 GOFLAGS ?= $(GOFLAGS:)
 BUILD_NUMBER ?= $(BUILD_NUMBER:)
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)
-CC_FOR_TARGET ?= "x86_64-linux-musl-gcc"
+LDFLAGS ?= $(LDFLAGS:)
 
+export GOBIN = $(PWD)/bin
 GO=go
 
 ifeq ($(BUILD_NUMBER),)
 	BUILD_NUMBER := dev
 endif
 
+LDFLAGS += -X "github.com/mattermost/mattermost-push-proxy/server.BuildNumber=$(BUILD_NUMBER)"
+LDFLAGS += -X "github.com/mattermost/mattermost-push-proxy/server.BuildDate=$(BUILD_DATE)"
+LDFLAGS += -X "github.com/mattermost/mattermost-push-proxy/server.BuildHash=$(BUILD_HASH)"
+
 DIST_ROOT=dist
 DIST_PATH=$(DIST_ROOT)/mattermost-push-proxy
-
-TESTS=.
 
 all: dist
 
@@ -25,14 +27,13 @@ check-style: gofmt govet
 dist: | gofmt govet build-server test package
 
 update-dependencies:
-	$(go) get -u ./...
-	$(go) mod tidy
+	$(GO) get -u ./...
+	$(GO) mod tidy
 
 build-server: gofmt govet
 	@echo Building proxy push server
 
-	$(GO) build $(GOFLAGS)
-	$(GO) install $(GOFLAGS)
+	$(GO) build -o $(GOBIN) -ldflags '$(LDFLAGS)' $(GOFLAGS)
 
 gofmt:
 	@echo GOFMT
@@ -47,16 +48,16 @@ gofmt:
 
 govet:
 	@echo Running govet
-	$(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet $$(go list ./...) .
-	$(GO) vet -vettool=$(GOPATH)/bin/shadow $$(go list ./...)
+	$(GO) vet -vettool=$(GOBIN)/shadow $$(go list ./...)
 	@echo Govet success
 
 package:
 	@ echo Packaging push proxy
 
 	mkdir -p $(DIST_PATH)/bin
-	cp $(GOPATH)/bin/mattermost-push-proxy $(DIST_PATH)/bin
+	cp $(GOBIN)/mattermost-push-proxy $(DIST_PATH)/bin
 
 	cp -RL config $(DIST_PATH)/config
 	touch $(DIST_PATH)/config/build.txt
@@ -71,7 +72,7 @@ package:
 	tar -C dist -czf $(DIST_PATH).tar.gz mattermost-push-proxy
 
 test:
-	$(GO) test $(GOFLAGS) -run=$(TESTS) -test.v -test.timeout=180s ./server || exit 1
+	$(GO) test $(GOFLAGS) -v -timeout=180s ./...
 
 clean:
 	@echo Cleaning
@@ -80,4 +81,4 @@ clean:
 
 run:
 	@echo Starting go web server
-	$(GO) run $(GOFLAGS) main.go
+	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' main.go

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files in this directory
+*
+# Except this one
+!.gitignore

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ var flagConfigFile string
 var stopChan chan os.Signal = make(chan os.Signal)
 
 func main() {
-
 	flag.StringVar(&flagConfigFile, "config", "mattermost-push-proxy.json", "")
 	flag.Parse()
 	server.LoadConfig(flagConfigFile)

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,12 @@ const (
 	CONNECTION_TIMEOUT_SECONDS = 60
 )
 
+var (
+	BuildNumber string
+	BuildDate   string
+	BuildHash   string
+)
+
 type NotificationServer interface {
 	SendNotification(msg *PushNotification) PushResponse
 	Initialize() bool
@@ -36,7 +42,7 @@ var servers map[string]NotificationServer = make(map[string]NotificationServer)
 var gracefulServer *graceful.Server
 
 func Start() {
-	LogInfo("Push proxy server is initializing...")
+	LogInfo(fmt.Sprintf("Push proxy server is initializing. BuildNumber: %s, BuildDate: %s, BuildHash: %s", BuildNumber, BuildDate, BuildHash))
 
 	proxyServer := getProxyServer()
 	if proxyServer != "" {


### PR DESCRIPTION
- Remove GOPATH and use GOBIN.
- Add the build variables to be actually used in code.
- Remove unnecessary go list commands.
- Remove unnecessary full-form of test flags.
- Set GO111MODULE=off while installing shadow.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-24316