### PR TITLE
MM-24319: Remove graceful

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/rakyll/pb v0.0.0-20160123035540-8d46b8b097ef // indirect
 	github.com/sideshow/apns2 v0.20.0
-	github.com/tylerb/graceful v1.2.15
 	golang.org/x/crypto v0.0.0-20200414173820-0848c9571904 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
-github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/server/server.go
+++ b/server/server.go
@@ -64,7 +64,6 @@ func Start() {
 	}
 
 	router := mux.NewRouter()
-	var handler http.Handler = router
 	vary := throttled.VaryBy{}
 	vary.RemoteAddr = false
 	vary.Headers = strings.Fields(CfgPP.ThrottleVaryByHeader)
@@ -75,7 +74,7 @@ func Start() {
 		throttled.DefaultDeniedHandler.ServeHTTP(w, r)
 	})
 
-	handler = th.Throttle(router)
+	handler := th.Throttle(router)
 
 	router.HandleFunc("/", root).Methods("GET")
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/tylerb/graceful"
 	"gopkg.in/throttled/throttled.v1"
 	throttledStore "gopkg.in/throttled/throttled.v1/store"
 )
@@ -39,7 +39,7 @@ type NotificationServer interface {
 
 var servers map[string]NotificationServer = make(map[string]NotificationServer)
 
-var gracefulServer *graceful.Server
+var server *http.Server
 
 func Start() {
 	LogInfo(fmt.Sprintf("Push proxy server is initializing. BuildNumber: %s, BuildDate: %s, BuildHash: %s", BuildNumber, BuildDate, BuildHash))
@@ -92,18 +92,15 @@ func Start() {
 	r.HandleFunc("/send_push", metricCompatibleSendNotificationHandler).Methods("POST")
 	r.HandleFunc("/ack", metricCompatibleAckNotificationHandler).Methods("POST")
 
+	server = &http.Server{
+		Addr:         CfgPP.ListenAddress,
+		Handler:      handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(handler),
+		ReadTimeout:  time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
+		WriteTimeout: time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
+	}
 	go func() {
-		gracefulServer = &graceful.Server{
-			Timeout: WAIT_FOR_SERVER_SHUTDOWN,
-			Server: &http.Server{
-				Addr:         CfgPP.ListenAddress,
-				Handler:      handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(handler),
-				ReadTimeout:  time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
-				WriteTimeout: time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
-			},
-		}
-		err := gracefulServer.ListenAndServe()
-		if err != nil {
+		err := server.ListenAndServe()
+		if err != http.ErrServerClosed {
 			LogCritical(err.Error())
 		}
 	}()
@@ -113,7 +110,13 @@ func Start() {
 
 func Stop() {
 	LogInfo("Stopping Server...")
-	gracefulServer.Stop(WAIT_FOR_SERVER_SHUTDOWN)
+	ctx, cancel := context.WithTimeout(context.Background(), WAIT_FOR_SERVER_SHUTDOWN)
+	defer cancel()
+	// Close shop
+	err := server.Shutdown(ctx)
+	if err != nil {
+		LogError(err.Error())
+	}
 }
 
 func root(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Since Go 1.8, the http server has a Shutdown method which performs
graceful shutdown. And this is mentioned in the graceful repo itself.