### PR TITLE
MM-18509: Revamp logging architecture

### DIFF
--- a/config/mattermost-push-proxy.json
+++ b/config/mattermost-push-proxy.json
@@ -29,5 +29,8 @@
             "Type":"android_rn",
             "AndroidApiKey":""
         }
-    ]
+    ],
+    "EnableConsoleLog": true,
+    "EnableFileLog": false,
+    "LogFileLocation": ""
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mattermost-push-proxy
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/PuerkitoBio/boom v0.0.0-20140219125548-fecdef1c97ca // indirect
 	github.com/appleboy/go-fcm v0.1.5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
@@ -18,9 +19,11 @@ require (
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/rakyll/pb v0.0.0-20160123035540-8d46b8b097ef // indirect
 	github.com/sideshow/apns2 v0.20.0
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20200414173820-0848c9571904 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/throttled/throttled.v1 v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/PuerkitoBio/boom v0.0.0-20140219125548-fecdef1c97ca h1:jv7AlMqwTYg92zzES80+2pXD0bPY5kGT3AhFKdXLLdI=
 github.com/PuerkitoBio/boom v0.0.0-20140219125548-fecdef1c97ca/go.mod h1:BUNf81ELJpN4dRN2LS5r1fkTSLkczJubIXjJv04ib70=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -144,6 +146,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/throttled/throttled.v1 v1.0.0 h1:HW4VuZPcA2x88dJSf3T7GLTOwYCrdQcYDEC65ZEX2mQ=
 gopkg.in/throttled/throttled.v1 v1.0.0/go.mod h1:UIVpydfpoUKqbHErIHUoEnuOj9KVPAmS88/iAIqBScE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
-	stopChan := make(chan os.Signal)
+	stopChan := make(chan os.Signal, 1)
 	signal.Notify(stopChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-stopChan
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"flag"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -14,19 +15,28 @@ import (
 
 var flagConfigFile string
 
-var stopChan chan os.Signal = make(chan os.Signal)
-
 func main() {
 	flag.StringVar(&flagConfigFile, "config", "mattermost-push-proxy.json", "")
 	flag.Parse()
-	server.LoadConfig(flagConfigFile)
 
-	server.Start()
+	fileName := server.FindConfigFile(flagConfigFile)
+	cfg, err := server.LoadConfig(fileName)
+	if err != nil {
+		// We just do a hard exit, because the app won't be able to start without a config.
+		log.Fatal(err)
+	}
+
+	logger := server.NewLogger(cfg)
+	logger.Info("Loading " + fileName)
+
+	srv := server.New(cfg, logger)
+	srv.Start()
 
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
+	stopChan := make(chan os.Signal)
 	signal.Notify(stopChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-stopChan
 
-	server.Stop()
+	srv.Stop()
 }

--- a/server/config_push_proxy.go
+++ b/server/config_push_proxy.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -79,7 +78,15 @@ func LoadConfig(fileName string) (*ConfigPushProxy, error) {
 	}
 	if cfg.EnableFileLog {
 		if cfg.LogFileLocation == "" {
-			return nil, errors.New("log file location not specified")
+			// We just do an mkdir -p equivalent.
+			// Otherwise, it would need 2 steps of statting and creating.
+			err := os.MkdirAll("./logs", 0755)
+			if err != nil {
+				// If it fails, we log in the current directory itself
+				cfg.LogFileLocation = "./push_proxy.log"
+			} else {
+				cfg.LogFileLocation = "./logs/push_proxy.log"
+			}
 		}
 		// if file does not exist, create it.
 		if _, err := os.Stat(cfg.LogFileLocation); os.IsNotExist(err) {

--- a/server/logger.go
+++ b/server/logger.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Logger is the struct to manage all logging operations in the application.
+type Logger struct {
+	cfg         *ConfigPushProxy
+	cInfoLogger *log.Logger
+	fInfoLogger *log.Logger
+	cErrLogger  *log.Logger
+	fErrLogger  *log.Logger
+}
+
+// NewLogger returns a new instance of the logger
+func NewLogger(cfg *ConfigPushProxy) *Logger {
+	l := &Logger{
+		cfg: cfg,
+	}
+	if cfg.EnableConsoleLog {
+		l.cInfoLogger = log.New(os.Stdout, "INFO: ", log.LstdFlags|log.Lshortfile)
+		l.cErrLogger = log.New(os.Stdout, "ERR: ", log.LstdFlags|log.Lshortfile)
+	}
+	if cfg.EnableFileLog {
+		lumber := &lumberjack.Logger{
+			Filename: cfg.LogFileLocation,
+			MaxSize:  10, // megabytes
+			Compress: true,
+		}
+		l.fInfoLogger = log.New(lumber, "INFO: ", log.LstdFlags|log.Lshortfile)
+		l.fErrLogger = log.New(lumber, "ERR: ", log.LstdFlags|log.Lshortfile)
+	}
+	return l
+}
+
+// Following are some helper methods that are called from the application.
+// They are divided into categories of Info(f), Error(f), and Panic(f).
+// They just forward to their underlying loggers depending on the config.
+
+func (l *Logger) Info(v ...interface{}) {
+	if l.cfg.EnableConsoleLog {
+		l.cInfoLogger.Println(v...)
+	}
+	if l.cfg.EnableFileLog {
+		l.fInfoLogger.Println(v...)
+	}
+}
+
+func (l *Logger) Infof(format string, v ...interface{}) {
+	if l.cfg.EnableConsoleLog {
+		l.cInfoLogger.Printf(format, v...)
+	}
+	if l.cfg.EnableFileLog {
+		l.fInfoLogger.Printf(format, v...)
+	}
+}
+
+func (l *Logger) Error(v ...interface{}) {
+	if l.cfg.EnableConsoleLog {
+		l.cErrLogger.Println(v...)
+	}
+	if l.cfg.EnableFileLog {
+		l.fErrLogger.Println(v...)
+	}
+}
+
+func (l *Logger) Errorf(format string, v ...interface{}) {
+	if l.cfg.EnableConsoleLog {
+		l.cErrLogger.Printf(format, v...)
+	}
+	if l.cfg.EnableFileLog {
+		l.fErrLogger.Printf(format, v...)
+	}
+}
+
+func (l *Logger) Panic(v ...interface{}) {
+	l.Error(v...)
+	panic(fmt.Sprintln(v...))
+}
+
+func (l *Logger) Panicf(format string, v ...interface{}) {
+	l.Errorf(format, v...)
+	panic(fmt.Sprintf(format, v...))
+}

--- a/server/logger_test.go
+++ b/server/logger_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerConsoleAndFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "log")
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	defer os.Remove(f.Name())
+
+	l := NewLogger(&ConfigPushProxy{
+		EnableConsoleLog: true,
+		EnableFileLog:    true,
+		LogFileLocation:  f.Name(),
+	})
+
+	// Resetting outputs to be consistent
+	var infoBuf, errBuf bytes.Buffer
+	l.cInfoLogger.SetOutput(&infoBuf)
+	l.cErrLogger.SetOutput(&errBuf)
+	l.cInfoLogger.SetFlags(0)
+	l.cErrLogger.SetFlags(0)
+	l.fInfoLogger.SetFlags(0)
+	l.fErrLogger.SetFlags(0)
+
+	t.Run("Info", func(t *testing.T) {
+		l.Info("hello world")
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		l.Infof("param %d", 1)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		l.Error("hello error")
+	})
+
+	t.Run("Errorf", func(t *testing.T) {
+		l.Errorf("err %d", 1)
+	})
+
+	buf, err := ioutil.ReadFile(f.Name())
+	require.NoError(t, err)
+	var total []byte
+	total = append(total, infoBuf.Bytes()...)
+	total = append(total, errBuf.Bytes()...)
+
+	assert.True(t, bytes.Equal(buf, total))
+
+	t.Run("Panic", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+		}()
+
+		l.Panic("something")
+	})
+
+	t.Run("Panicf", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r)
+		}()
+
+		l.Panicf("param %d", 1)
+	})
+}
+
+func TestLoggerConsole(t *testing.T) {
+	f, err := ioutil.TempFile("", "log")
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	defer os.Remove(f.Name())
+
+	l := NewLogger(&ConfigPushProxy{
+		EnableConsoleLog: true,
+		EnableFileLog:    false,
+		LogFileLocation:  f.Name(),
+	})
+
+	// Resetting outputs to be consistent
+	var infoBuf, errBuf bytes.Buffer
+	l.cInfoLogger.SetOutput(&infoBuf)
+	l.cErrLogger.SetOutput(&errBuf)
+
+	t.Run("Info", func(t *testing.T) {
+		l.Info("hello world")
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		l.Infof("param %d", 1)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		l.Error("hello error")
+	})
+
+	t.Run("Errorf", func(t *testing.T) {
+		l.Errorf("err %d", 1)
+	})
+
+	buf, err := ioutil.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Empty(t, buf)
+}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -8,19 +8,27 @@ import (
 	"time"
 
 	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetricDisabled(t *testing.T) {
 	t.Log("Testing Metrics Enabled")
-	LoadConfig("mattermost-push-proxy.json")
 	platform := "junk"
 	pushType := PushTypeMessage
-	CfgPP.AndroidPushSettings[0].AndroidAPIKey = platform
-	CfgPP.EnableMetrics = false
-	Start()
+
+	fileName := FindConfigFile("mattermost-push-proxy.json")
+	cfg, err := LoadConfig(fileName)
+	require.NoError(t, err)
+	cfg.AndroidPushSettings[0].AndroidAPIKey = platform
+	cfg.EnableMetrics = false
+
+	logger := NewLogger(cfg)
+	srv := New(cfg, logger)
+	srv.Start()
+
 	time.Sleep(time.Second * 2)
 	defer func() {
-		Stop()
+		srv.Stop()
 		time.Sleep(time.Second * 2)
 	}()
 
@@ -50,15 +58,22 @@ func TestMetricDisabled(t *testing.T) {
 
 func TestMetricEnabled(t *testing.T) {
 	t.Log("Testing Metrics Enabled")
-	LoadConfig("mattermost-push-proxy.json")
 	platform := "junk"
 	pushType := PushTypeMessage
-	CfgPP.AndroidPushSettings[0].AndroidAPIKey = platform
-	CfgPP.EnableMetrics = true
-	Start()
+
+	fileName := FindConfigFile("mattermost-push-proxy.json")
+	cfg, err := LoadConfig(fileName)
+	require.NoError(t, err)
+	cfg.AndroidPushSettings[0].AndroidAPIKey = platform
+	cfg.EnableMetrics = true
+
+	logger := NewLogger(cfg)
+	srv := New(cfg, logger)
+	srv.Start()
+
 	time.Sleep(time.Second * 2)
 	defer func() {
-		Stop()
+		srv.Stop()
 		time.Sleep(time.Second * 2)
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -6,7 +6,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -37,40 +36,54 @@ type NotificationServer interface {
 	Initialize() bool
 }
 
-var servers map[string]NotificationServer = make(map[string]NotificationServer)
+// Server is the main struct which performs all activities.
+type Server struct {
+	cfg         *ConfigPushProxy
+	httpServer  *http.Server
+	pushTargets map[string]NotificationServer
+	logger      *Logger
+}
 
-var server *http.Server
+// New returns a new Server instance.
+func New(cfg *ConfigPushProxy, logger *Logger) *Server {
+	return &Server{
+		cfg:         cfg,
+		pushTargets: make(map[string]NotificationServer),
+		logger:      logger,
+	}
+}
 
-func Start() {
-	LogInfo(fmt.Sprintf("Push proxy server is initializing. BuildNumber: %s, BuildDate: %s, BuildHash: %s", BuildNumber, BuildDate, BuildHash))
+// Start starts the server.
+func (s *Server) Start() {
+	s.logger.Infof("Push proxy server is initializing. BuildNumber: %s, BuildDate: %s, BuildHash: %s", BuildNumber, BuildDate, BuildHash)
 
 	proxyServer := getProxyServer()
 	if proxyServer != "" {
-		LogInfo(fmt.Sprintf("Proxy server detected. Routing all requests through: %s", proxyServer))
+		s.logger.Infof("Proxy server detected. Routing all requests through: %s", proxyServer)
 	}
 
-	for _, settings := range CfgPP.ApplePushSettings {
-		server := NewAppleNotificationServer(settings)
+	for _, settings := range s.cfg.ApplePushSettings {
+		server := NewAppleNotificationServer(settings, s.logger)
 		if server.Initialize() {
-			servers[settings.Type] = server
+			s.pushTargets[settings.Type] = server
 		}
 	}
 
-	for _, settings := range CfgPP.AndroidPushSettings {
-		server := NewAndroideNotificationServer(settings)
+	for _, settings := range s.cfg.AndroidPushSettings {
+		server := NewAndroidNotificationServer(settings, s.logger)
 		if server.Initialize() {
-			servers[settings.Type] = server
+			s.pushTargets[settings.Type] = server
 		}
 	}
 
 	router := mux.NewRouter()
 	vary := throttled.VaryBy{}
 	vary.RemoteAddr = false
-	vary.Headers = strings.Fields(CfgPP.ThrottleVaryByHeader)
-	th := throttled.RateLimit(throttled.PerSec(CfgPP.ThrottlePerSec), &vary, throttledStore.NewMemStore(CfgPP.ThrottleMemoryStoreSize))
+	vary.Headers = strings.Fields(s.cfg.ThrottleVaryByHeader)
+	th := throttled.RateLimit(throttled.PerSec(s.cfg.ThrottlePerSec), &vary, throttledStore.NewMemStore(s.cfg.ThrottleMemoryStoreSize))
 
 	th.DeniedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		LogError(fmt.Sprintf("%v: code=429 ip=%v", r.URL.Path, GetIpAddress(r)))
+		s.logger.Errorf("%v: code=429 ip=%v", r.URL.Path, s.getIpAddress(r))
 		throttled.DefaultDeniedHandler.ServeHTTP(w, r)
 	})
 
@@ -78,43 +91,44 @@ func Start() {
 
 	router.HandleFunc("/", root).Methods("GET")
 
-	metricCompatibleSendNotificationHandler := handleSendNotification
-	metricCompatibleAckNotificationHandler := handleAckNotification
-	if CfgPP.EnableMetrics {
+	metricCompatibleSendNotificationHandler := s.handleSendNotification
+	metricCompatibleAckNotificationHandler := s.handleAckNotification
+	if s.cfg.EnableMetrics {
 		MetricsEnabled = true
 		metrics := NewPrometheusHandler()
 		router.Handle("/metrics", metrics).Methods("GET")
-		metricCompatibleSendNotificationHandler = responseTimeMiddleware(handleSendNotification)
-		metricCompatibleAckNotificationHandler = responseTimeMiddleware(handleAckNotification)
+		metricCompatibleSendNotificationHandler = responseTimeMiddleware(s.handleSendNotification)
+		metricCompatibleAckNotificationHandler = responseTimeMiddleware(s.handleAckNotification)
 	}
 	r := router.PathPrefix("/api/v1").Subrouter()
 	r.HandleFunc("/send_push", metricCompatibleSendNotificationHandler).Methods("POST")
 	r.HandleFunc("/ack", metricCompatibleAckNotificationHandler).Methods("POST")
 
-	server = &http.Server{
-		Addr:         CfgPP.ListenAddress,
+	s.httpServer = &http.Server{
+		Addr:         s.cfg.ListenAddress,
 		Handler:      handlers.RecoveryHandler(handlers.PrintRecoveryStack(true))(handler),
 		ReadTimeout:  time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
 		WriteTimeout: time.Duration(CONNECTION_TIMEOUT_SECONDS) * time.Second,
 	}
 	go func() {
-		err := server.ListenAndServe()
+		err := s.httpServer.ListenAndServe()
 		if err != http.ErrServerClosed {
-			LogCritical(err.Error())
+			s.logger.Panic(err.Error())
 		}
 	}()
 
-	LogInfo("Server is listening on " + CfgPP.ListenAddress)
+	s.logger.Info("Server is listening on " + s.cfg.ListenAddress)
 }
 
-func Stop() {
-	LogInfo("Stopping Server...")
+// Stop stops the server.
+func (s *Server) Stop() {
+	s.logger.Info("Stopping Server...")
 	ctx, cancel := context.WithTimeout(context.Background(), WAIT_FOR_SERVER_SHUTDOWN)
 	defer cancel()
 	// Close shop
-	err := server.Shutdown(ctx)
+	err := s.httpServer.Shutdown(ctx)
 	if err != nil {
-		LogError(err.Error())
+		s.logger.Error(err.Error())
 	}
 }
 
@@ -130,26 +144,32 @@ func responseTimeMiddleware(f func(w http.ResponseWriter, r *http.Request)) func
 	}
 }
 
-func handleSendNotification(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) {
 	msg := PushNotificationFromJson(r.Body)
 
 	if msg == nil {
-		rMsg := LogError("Failed to read message body")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		rMsg := "Failed to read message body"
+		s.logger.Error(rMsg)
+		resp := NewErrorPushResponse(rMsg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	if len(msg.ServerID) == 0 {
-		rMsg := LogError("Failed because of missing server Id")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		rMsg := "Failed because of missing server Id"
+		s.logger.Error(rMsg)
+		resp := NewErrorPushResponse(rMsg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	if len(msg.DeviceID) == 0 {
-		rMsg := LogError(fmt.Sprintf("Failed because of missing device Id serverId=%v", msg.ServerID))
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		rMsg := fmt.Sprintf("Failed because of missing device Id serverId=%v", msg.ServerID)
+		s.logger.Error(rMsg)
+		resp := NewErrorPushResponse(rMsg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
@@ -158,76 +178,68 @@ func handleSendNotification(w http.ResponseWriter, r *http.Request) {
 		msg.Message = msg.Message[0:2046]
 	}
 
-	if server, ok := servers[msg.Platform]; ok {
+	if server, ok := s.pushTargets[msg.Platform]; ok {
 		rMsg := server.SendNotification(msg)
 		_, _ = w.Write([]byte(rMsg.ToJson()))
 		return
 	} else {
-		rMsg := LogError(fmt.Sprintf("Did not send message because of missing platform property type=%v serverId=%v", msg.Platform, msg.ServerID))
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		rMsg := fmt.Sprintf("Did not send message because of missing platform property type=%v serverId=%v", msg.Platform, msg.ServerID)
+		s.logger.Error(rMsg)
+		resp := NewErrorPushResponse(rMsg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 }
 
-func handleAckNotification(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 	ack := PushNotificationAckFromJSON(r.Body)
 
 	if ack == nil {
-		rMsg := LogError("Failed to read ack body")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		msg := "Failed to read ack body"
+		s.logger.Error(msg)
+		resp := NewErrorPushResponse(msg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	if len(ack.ID) == 0 {
-		rMsg := LogError("Failed because of missing ack Id")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		msg := "Failed because of missing ack Id"
+		s.logger.Error(msg)
+		resp := NewErrorPushResponse(msg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	if len(ack.Platform) == 0 {
-		rMsg := LogError("Failed because of missing ack platform")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		msg := "Failed because of missing ack platform"
+		s.logger.Error(msg)
+		resp := NewErrorPushResponse(msg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	if len(ack.Type) == 0 {
-		rMsg := LogError("Failed because of missing ack type")
-		_, _ = w.Write([]byte(rMsg.ToJson()))
+		msg := "Failed because of missing ack type"
+		s.logger.Error(msg)
+		resp := NewErrorPushResponse(msg)
+		_, _ = w.Write([]byte(resp.ToJson()))
 		incrementBadRequest()
 		return
 	}
 
 	// Increment ACK
-	LogInfo(fmt.Sprintf("Acknowledge delivery receipt for AckId=%v", ack.ID))
+	s.logger.Infof("Acknowledge delivery receipt for AckId=%v", ack.ID)
 	incrementDelivered(ack.Platform, ack.Type)
 
 	rMsg := NewOkPushResponse()
 	_, _ = w.Write([]byte(rMsg.ToJson()))
 }
 
-func LogInfo(msg string) {
-	Log("INFO", msg)
-}
-
-func LogError(msg string) PushResponse {
-	Log("ERROR", msg)
-	return NewErrorPushResponse(msg)
-}
-
-func LogCritical(msg string) {
-	Log("CRIT", msg)
-	panic(msg)
-}
-
-func Log(level string, msg string) {
-	log.Printf("%v %v\n", level, msg)
-}
-
-func GetIpAddress(r *http.Request) string {
+func (s *Server) getIpAddress(r *http.Request) string {
 	address := r.Header.Get(HEADER_FORWARDED)
 	var err error
 
@@ -238,7 +250,7 @@ func GetIpAddress(r *http.Request) string {
 	if len(address) == 0 {
 		address, _, err = net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
-			LogError(fmt.Sprintf("error in getting IP address: %v", err))
+			s.logger.Errorf("error in getting IP address: %v", err)
 		}
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,11 +8,19 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasicServer(t *testing.T) {
-	LoadConfig("mattermost-push-proxy.json")
-	Start()
+	fileName := FindConfigFile("mattermost-push-proxy.json")
+	cfg, err := LoadConfig(fileName)
+	require.NoError(t, err)
+
+	logger := NewLogger(cfg)
+	srv := New(cfg, logger)
+	srv.Start()
+
 	time.Sleep(time.Second * 2)
 
 	msg := PushNotification{}
@@ -58,14 +66,20 @@ func TestBasicServer(t *testing.T) {
 		}
 	}
 
-	Stop()
+	srv.Stop()
 	time.Sleep(time.Second * 2)
 }
 
 func TestAndroidSend(t *testing.T) {
-	LoadConfig("mattermost-push-proxy.json")
-	CfgPP.AndroidPushSettings[0].AndroidAPIKey = "junk"
-	Start()
+	fileName := FindConfigFile("mattermost-push-proxy.json")
+	cfg, err := LoadConfig(fileName)
+	require.NoError(t, err)
+
+	cfg.AndroidPushSettings[0].AndroidAPIKey = "junk"
+	logger := NewLogger(cfg)
+	srv := New(cfg, logger)
+	srv.Start()
+
 	time.Sleep(time.Second * 2)
 
 	msg := PushNotification{}
@@ -86,6 +100,6 @@ func TestAndroidSend(t *testing.T) {
 		}
 	}
 
-	Stop()
+	srv.Stop()
 	time.Sleep(time.Second * 2)
 }


### PR DESCRIPTION
With this PR, we attempt to completely overhaul the logging mechanism
of the push proxy. There were 2 primary shortcomings which are addressed:
- Config struct was a global variable shared amongst the entire codebase.
- Log methods were global functions which were being called from everywhere.

To fix this,
- We create a server struct and convert the start and stop into methods.
- Pass the config struct into this server struct, so that all state is localized.

For file logging, we use the lumberjack writer which automatically takes care of
file rotation which is a nice thing to have.
By default, if the fields are not set (which would be the case if the config file
wasn't changed), the default behavior of only logging to console would be maintained.

Other notable improvements are:
- Fix a small typo.
- Remove global signal channel.

Overall, this reduces the public API surface by a lot. And adds an improved logging API
with dedicated formatter methods to avoid creating ugly fmt.Sprintf strings.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-18509
