### PR TITLE
MM-25674: Add session type to push proxy

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -49,7 +49,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		data["id_loaded"] = true
 		data["sender_id"] = msg.SenderID
 		data["sender_name"] = "Someone"
-	} else if pushType == PushTypeMessage {
+	} else if pushType == PushTypeMessage || pushType == PushTypeSession {
 		data["team_id"] = msg.TeamID
 		data["sender_id"] = msg.SenderID
 		data["sender_name"] = msg.SenderName

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -95,7 +95,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 		data.AlertBody(msg.Message)
 	} else {
 		switch msg.Type {
-		case PushTypeMessage:
+		case PushTypeMessage, PushTypeSession:
 			data.Category(msg.Category)
 			data.Sound("default")
 			data.Custom("version", msg.Version)

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -15,6 +15,7 @@ const (
 	PushTypeMessage     = "message"
 	PushTypeClear       = "clear"
 	PushTypeUpdateBadge = "update_badge"
+	PushTypeSession     = "session"
 
 	PushMessageV2 = "v2"
 


### PR DESCRIPTION
This PR adds support for the session notification type.
The behavior is the same as a normal message type, and is used
by the mobile device to differentiate.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-25674