### PR TITLE
Remove golangci-lint from build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ update-dependencies:
 	$(GO) get -u ./...
 	$(GO) mod tidy
 
-build-server: gofmt golangci-lint
+build-server: gofmt
 	@echo Building proxy push server
 
 	$(GO) build -o $(GOBIN) -ldflags '$(LDFLAGS)' $(GOFLAGS)


### PR DESCRIPTION
The lint check is already part of make golangci-lint
which is called explicitly. But making it part of build step
causes the tagged-build to fail because golangci-lint doesn't get installed
as part of make golangci-lint.

We remove it because building doesn't really require linting to succeed.

Failure here: https://app.circleci.com/jobs/github/mattermost/mattermost-push-proxy/245