### PR TITLE
Use an image with docker installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
           arguments: --acl public-read --cache-control "no-cache"
 
   push-docker:
+    docker:
+      - image: circleci/golang:1.14
     executor:
       name: default
     steps:


### PR DESCRIPTION
Using mattermost/mattermost-build-server:20200322_golang-1.14.1 as the default image
causes failure in the docker build step because that image does not have docker installed.

We use the circleCI docker image for this to build the image. There is no need for mattermost
specific stuff for building docker image.
