### PR TITLE
Remove dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Manually reviewing the PRs is an additional headache we don't want to take. We will update the dependencies manually like we do for server.
