### PR TITLE
Add support for Apple APNS AuthKey

### DIFF
--- a/config/mattermost-push-proxy.json
+++ b/config/mattermost-push-proxy.json
@@ -10,14 +10,20 @@
             "ApplePushUseDevelopment":false,
             "ApplePushCertPrivate":"",
             "ApplePushCertPassword":"",
-            "ApplePushTopic":"com.mattermost.Mattermost"
+            "ApplePushTopic":"com.mattermost.Mattermost",
+            "AppleAuthKeyFile": "",
+            "AppleAuthKeyID": "",
+            "AppleTeamID": ""
         },
         {
             "Type":"apple_rn",
             "ApplePushUseDevelopment":false,
             "ApplePushCertPrivate":"",
             "ApplePushCertPassword":"",
-            "ApplePushTopic":"com.mattermost.react.native"
+            "ApplePushTopic":"com.mattermost.react.native",
+            "AppleAuthKeyFile": "",
+            "AppleAuthKeyID": "",
+            "AppleTeamID": ""
         }
     ],
     "AndroidPushSettings":[

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -32,6 +32,41 @@ func NewAppleNotificationServer(settings ApplePushSettings, logger *Logger, metr
 	}
 }
 
+func (me *AppleNotificationServer) setupProxySettings(appleCert *tls.Certificate) bool {
+	// Override the native transport.
+	proxyServer := getProxyServer()
+	if proxyServer != "" {
+		transport := &http.Transport{
+			Proxy: func(request *http.Request) (*url.URL, error) {
+				return url.Parse(proxyServer)
+			},
+			IdleConnTimeout: apns.HTTPClientTimeout,
+		}
+
+		if appleCert != nil {
+			transport.TLSClientConfig = &tls.Config{
+				Certificates: []tls.Certificate{*appleCert},
+			}
+		}
+
+		err := http2.ConfigureTransport(transport)
+		if err != nil {
+			me.logger.Errorf("Transport Error: %v", err)
+			return false
+		}
+
+		me.AppleClient.HTTPClient.Transport = transport
+	}
+
+	if appleCert != nil {
+		me.logger.Infof("Initializing apple notification server for type=%v with PEM certificate", me.ApplePushSettings.Type)
+	} else {
+		me.logger.Infof("Initializing apple notification server for type=%v with AuthKey", me.ApplePushSettings.Type)
+	}
+
+	return true
+}
+
 func (me *AppleNotificationServer) Initialize() bool {
 	if me.ApplePushSettings.AppleAuthKeyFile != "" && me.ApplePushSettings.AppleAuthKeyID != "" && me.ApplePushSettings.AppleTeamID != "" {
 		authKey, err := token.AuthKeyFromFile(me.ApplePushSettings.AppleAuthKeyFile)
@@ -52,27 +87,10 @@ func (me *AppleNotificationServer) Initialize() bool {
 		}
 
 		// Override the native transport.
-		proxyServer := getProxyServer()
-		if proxyServer != "" {
-			transport := &http.Transport{
-				Proxy: func(request *http.Request) (*url.URL, error) {
-					return url.Parse(proxyServer)
-				},
-				IdleConnTimeout: apns.HTTPClientTimeout,
-			}
-			err := http2.ConfigureTransport(transport)
-			if err != nil {
-				me.logger.Errorf("Transport Error: %v", err)
-				return false
-			}
+		return me.setupProxySettings(nil)
+	}
 
-			me.AppleClient.HTTPClient.Transport = transport
-		}
-
-		me.logger.Infof("Initializing apple notification server for type=%v with AuthKey", me.ApplePushSettings.Type)
-
-		return true
-	} else if me.ApplePushSettings.ApplePushCertPrivate != "" {
+	if me.ApplePushSettings.ApplePushCertPrivate != "" {
 		appleCert, appleCertErr := certificate.FromPemFile(me.ApplePushSettings.ApplePushCertPrivate, me.ApplePushSettings.ApplePushCertPassword)
 		if appleCertErr != nil {
 			me.logger.Panicf("Failed to initialize apple notification service with pem cert err=%v for type=%v", appleCertErr, me.ApplePushSettings.Type)
@@ -86,35 +104,11 @@ func (me *AppleNotificationServer) Initialize() bool {
 		}
 
 		// Override the native transport.
-		proxyServer := getProxyServer()
-		if proxyServer != "" {
-			tlsConfig := &tls.Config{
-				Certificates: []tls.Certificate{appleCert},
-			}
-
-			transport := &http.Transport{
-				TLSClientConfig: tlsConfig,
-				Proxy: func(request *http.Request) (*url.URL, error) {
-					return url.Parse(proxyServer)
-				},
-				IdleConnTimeout: apns.HTTPClientTimeout,
-			}
-			err := http2.ConfigureTransport(transport)
-			if err != nil {
-				me.logger.Errorf("Transport Error: %v", err)
-				return false
-			}
-
-			me.AppleClient.HTTPClient.Transport = transport
-		}
-
-		me.logger.Infof("Initializing apple notification server for type=%v with PEM certificate", me.ApplePushSettings.Type)
-
-		return true
-	} else {
-		me.logger.Errorf("Apple push notifications not configured.  Missing ApplePushCertPrivate. for type=%v", me.ApplePushSettings.Type)
-		return false
+		return me.setupProxySettings(&appleCert)
 	}
+
+	me.logger.Errorf("Apple push notifications not configured.  Missing ApplePushCertPrivate. for type=%v", me.ApplePushSettings.Type)
+	return false
 }
 
 func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushResponse {

--- a/server/config_push_proxy.go
+++ b/server/config_push_proxy.go
@@ -29,6 +29,9 @@ type ApplePushSettings struct {
 	ApplePushCertPrivate    string
 	ApplePushCertPassword   string
 	ApplePushTopic          string
+	AppleAuthKeyFile        string
+	AppleAuthKeyID          string
+	AppleTeamID             string
 	ApplePushUseDevelopment bool
 }
 


### PR DESCRIPTION
#### Summary
This PR adds support for [Apple AuthKey](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns?language=objc) with this we will be using the same key for all Apple topics (one per-app) which means that the same key will WORK with every app we ship, also this removes the need to having to renew certificates every year. Also for customers the setup for APN is going to be much easier than the current certificate conversion to PEM.

#### Ticket Link
N/A
