### PR TITLE
Add app version if available

### DIFF
--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -80,7 +80,9 @@ func (me *AppleNotificationServer) Initialize() bool {
 func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushResponse {
 
 	data := payload.NewPayload()
-	if msg.Badge != -1 {
+	if msg.Badge == 0 && msg.Type == PushTypeClear && msg.AppVersion > 1 {
+		data.Badge(1)
+	} else if msg.Badge != -1 {
 		data.Badge(msg.Badge)
 	}
 

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -50,6 +50,7 @@ type PushNotification struct {
 	OverrideIconURL  string `json:"override_icon_url"`
 	FromWebhook      string `json:"from_webhook"`
 	Version          string `json:"version"`
+	AppVersion       int    `json:"app_version,omitempty"`
 	Badge            int    `json:"badge"`
 	ContentAvailable int    `json:"cont_ava"`
 	IsCRTEnabled     bool   `json:"is_crt_enabled"`

--- a/server/server.go
+++ b/server/server.go
@@ -196,19 +196,18 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 	// Parse the app version if available
 	index := strings.Index(msg.Platform, "-v")
 	platform := msg.Platform
-	appVersion := 1
+	msg.AppVersion = 1
 	if index > -1 {
 		msg.Platform = platform[:index]
 		appVersionString := platform[index+2:]
 		version, e := strconv.Atoi(appVersionString)
 		if e == nil {
-			appVersion = version
+			msg.AppVersion = version
 		} else {
 			rMsg := fmt.Sprintf("Could not determine the app version in %v appVersion=%v", msg.Platform, appVersionString)
 			s.logger.Error(rMsg)
 		}
 	}
-	msg.AppVersion = appVersion
 
 	if server, ok := s.pushTargets[msg.Platform]; ok {
 		rMsg := server.SendNotification(msg)

--- a/server/server.go
+++ b/server/server.go
@@ -192,6 +192,17 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 		msg.Message = msg.Message[0:2046]
 	}
 
+	// Parse the app version if available
+	index := strings.Index(msg.Platform, "-v")
+	platform := msg.Platform
+	appVersion := 1
+	if index > -1 {
+		msg.Platform = platform[:index]
+		appVersionString := platform[index+2:]
+		fmt.Sscan(appVersionString, &appVersion)
+	}
+	msg.AppVersion = appVersion
+
 	if server, ok := s.pushTargets[msg.Platform]; ok {
 		rMsg := server.SendNotification(msg)
 		_, _ = w.Write([]byte(rMsg.ToJson()))

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -199,7 +200,13 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 	if index > -1 {
 		msg.Platform = platform[:index]
 		appVersionString := platform[index+2:]
-		fmt.Sscan(appVersionString, &appVersion)
+		version, e := strconv.Atoi(appVersionString)
+		if e == nil {
+			appVersion = version
+		} else {
+			rMsg := fmt.Sprintf("Could not determine the app version in %v appVersion=%v", msg.Platform, appVersionString)
+			s.logger.Error(rMsg)
+		}
 	}
 	msg.AppVersion = appVersion
 


### PR DESCRIPTION
#### Summary
With multiple server support we will now receive notifications from more than one server at a time, this notifications also include a silent notification when a channel/thread is read.

We use this silent notification to remove notifications that belong to this channel/thread from the notification center on Both Android and iOS.

There is an issue though. Once there are no more mentions the clear notification includes a badge with a value of `0`. When the badge is `0` on iOS devices it will remove every single notification from the Notification center even those notifications from another server that you haven't read. This can cause frustration.

To avoid this scenario, I made a change to get the `appVersion` by adding a suffix of `-v` to the platform string, so we will check for the existence of this suffix to set the "appVersion" and default to "1" if it does not exist to be backwards compatible.

Then if the appVersion is greater than one it means that the app supports multiple servers, thus for a clear notification that has a badge number of zero, we will replace it with a badge of 1. By having the number one only the notifications that belong to the channel/thread are going to be removed from the notification center leaving the other ones in place.

The app internally will update the badge number on the app icon to match the amount of unread mentions and if there are no more mentions, the app will remove the badge from the icon.

This PR is mandatory before we deploy the first alpha version of v2.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43486

