### PR TITLE
MM-53924 - Include category in the Android payload

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -44,6 +44,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		"channel_id":     msg.ChannelID,
 		"is_crt_enabled": msg.IsCRTEnabled,
 		"server_id":      msg.ServerID,
+		"category":       msg.Category,
 	}
 
 	if msg.Badge != -1 {


### PR DESCRIPTION
#### Summary
- Include the `category` field for Android notification. Android clients can use that field to determine whether or not to add reply actions. 
- This will allow Android to match how iOS handles the `category` field.
- Implemented in: https://github.com/mattermost/mattermost-mobile/pull/7534

#### Ticket Link
- This is ultimately because Calls wants to remove the "Okay" etc. auto reply options when we send a new call notification. https://mattermost.atlassian.net/browse/MM-53924
