### PR TITLE
CLD-6410 [fix] Add the dir "logs" into the tarball structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ package-software:  ## to package the binary
 		cp -RL config $(GO_OUT_BIN_DIR)/$${target}_temp/config; \
 		echo $(APP_VERSION) > $(GO_OUT_BIN_DIR)/$${target}_temp/config/build.txt; \
 		cp LICENSE.txt NOTICE.txt README.md $(GO_OUT_BIN_DIR)/$${target}_temp; \
+		mkdir $(GO_OUT_BIN_DIR)/$${target}_temp/logs; \
 		mv $$file $(GO_OUT_BIN_DIR)/$${target}_temp/bin/mattermost-push-proxy; \
 		mv $(GO_OUT_BIN_DIR)/$${target}_temp $(GO_OUT_BIN_DIR)/$${target}; \
 		tar -czf $(GO_OUT_BIN_DIR)/$${target}.tar.gz -C $(GO_OUT_BIN_DIR) $${target}; \


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

With the changes introduced under https://github.com/mattermost/mattermost-push-proxy/pull/109 We missed the `logs` directory from the tarbal generation.

We fix this now.

before:
```
├── LICENSE.txt
├── NOTICE.txt
├── README.md
├── bin
│   └── mattermost-push-proxy
└── config
    ├── build.txt
    └── mattermost-push-proxy.sample.json
```

after:
```
├── LICENSE.txt
├── NOTICE.txt
├── README.md
├── bin
│   └── mattermost-push-proxy
├── config
│   ├── build.txt
│   └── mattermost-push-proxy.sample.json
└── logs
```

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-6410
