### PR TITLE
feat: Adding auto bumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # Mattermost Push Proxy ![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-push-proxy/master.svg)
 
 See https://developers.mattermost.com/contribute/mobile/push-notifications/service/
+
+
+# How to Release
+
+To trigger a release of Mattermost Push-Proxy, follow these steps:
+
+1. **For Patch Release:** Run the following command:
+    ```
+    make patch
+    ```
+   This will release a patch change.
+
+2. **For Minor Release:** Run the following command:
+    ```
+    make minor
+    ```
+   This will release a minor change.
+
+3. **For Major Release:** Run the following command:
+    ```
+    make major
+    ```
+   This will release a major change.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adding release instructions, and relevant Makefile targets 

```
Usage:
make help                           to get help
make build                          to build
make release                        to build and release artifacts
make package                        to build, package
make sign                           to sign the artifact and perform verification
make lint                           to lint
make test                           to test
make patch                          to bump patch version (semver)
make minor                          to bump minor version (semver)
make major                          to bump major version (semver)
make package-software               to package the binary
make docker-build                   to build the docker image
make docker-push                    to push the docker image
make docker-sign                    to sign the docker image
make docker-verify                  to verify the docker image
make docker-sbom                    to print a sbom report
make docker-scan                    to print a vulnerability report
make docker-lint                    to lint the Dockerfile
make docker-login                   to login to a container registry
make go-build                       to build binaries
make go-run                         to run locally for development
make go-test                        to run tests
make go-mod-check                   to check go mod files consistency
make go-lint                        to lint go code
make go-doc                         to generate documentation
make github-release                 to publish a release and relevant artifacts to GitHub
make clean                          to clean-up
```


```
> make patch                                                                                                                      
[ .. ] Bumping mattermost-push-proxy to Patch version 6.0.1
git tag -a 6.0.1 -m "Bumping mattermost-push-proxy to Patch version 6.0.1"
[ OK ] Bumping mattermost-push-proxy to Patch version 6.0.1
> make patch     
12:37:30 [ .. ] Bumping mattermost-push-proxy to Patch version 6.0.2
git tag -a 6.0.2 -m "Bumping mattermost-push-proxy to Patch version 6.0.2"
12:37:30 [ OK ] Bumping mattermost-push-proxy to Patch version 6.0.2

> make minor                                                                                                                         
[ .. ] Bumping mattermost-push-proxy to Minor version 6.1.0
git tag -a 6.1.0 -m "Bumping mattermost-push-proxy to Minor version 6.1.0"
[ OK ] Bumping mattermost-push-proxy to Minor version 6.1.0

> make major                                                                                                                   
[ .. ] Bumping mattermost-push-proxy to Major version 7.0.0
git tag -a 7.0.0 -m "Bumping mattermost-push-proxy to Major version 7.0.0"
[ OK ] Bumping mattermost-push-proxy to Major version 7.0.0
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

