### PR TITLE
[fix] Release bump script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,14 @@ test: go-test ## to test
 patch: ## to bump patch version (semver)
 	@$(eval PATCH := $(shell echo $$(($(PATCH)+1))))
 	@$(INFO) Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)
-	git tag -s -a $(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)"
+	git tag -s -a v$(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)"
 	git push --tags
 	@$(OK) Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)
 
 minor: ## to bump minor version (semver)
 	@$(eval MINOR := $(shell echo $$(($(MINOR)+1))))
 	@$(INFO) Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0
-	git tag -s -a $(MAJOR).$(MINOR).0 -m "Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0"
+	git tag -s -a v$(MAJOR).$(MINOR).0 -m "Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0"
 	git push --tags
 	@$(OK) Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0
 
@@ -193,7 +193,7 @@ major: ## to bump major version (semver)
 	$(eval MINOR := 0)
 	$(eval PATCH := 0)
 	@$(INFO) Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)
-	git tag -s -a $(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)"
+	git tag -s -a v$(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)"
 	git push --tags
 	@$(OK) Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)
 

--- a/Makefile
+++ b/Makefile
@@ -178,14 +178,14 @@ patch: ## to bump patch version (semver)
 	@$(eval PATCH := $(shell echo $$(($(PATCH)+1))))
 	@$(INFO) Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)
 	git tag -s -a v$(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)"
-	git push --tags
+	git push origin v$(MAJOR).$(MINOR).$(PATCH)
 	@$(OK) Bumping $(APP_NAME) to Patch version $(MAJOR).$(MINOR).$(PATCH)
 
 minor: ## to bump minor version (semver)
 	@$(eval MINOR := $(shell echo $$(($(MINOR)+1))))
 	@$(INFO) Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0
 	git tag -s -a v$(MAJOR).$(MINOR).0 -m "Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0"
-	git push --tags
+	git push origin v$(MAJOR).$(MINOR).$(PATCH)
 	@$(OK) Bumping $(APP_NAME) to Minor version $(MAJOR).$(MINOR).0
 
 major: ## to bump major version (semver)
@@ -194,7 +194,7 @@ major: ## to bump major version (semver)
 	$(eval PATCH := 0)
 	@$(INFO) Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)
 	git tag -s -a v$(MAJOR).$(MINOR).$(PATCH) -m "Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)"
-	git push --tags
+	git push origin v$(MAJOR).$(MINOR).$(PATCH)
 	@$(OK) Bumping $(APP_NAME) to Major version $(MAJOR).$(MINOR).$(PATCH)
 
 package-software:  ## to package the binary


### PR DESCRIPTION
We parse tags for building,  using v{semver} instead of {semver} Fixing that here.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

