### PR TITLE
Limit channel name size

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -219,6 +219,10 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 		msg.Message = msg.Message[0:2046]
 	}
 
+	if len(msg.ChannelName) > 64 {
+		msg.ChannelName = msg.ChannelName[0:64]
+	}
+
 	// Parse the app version if available
 	index := strings.Index(msg.Platform, "-v")
 	platform := msg.Platform


### PR DESCRIPTION
#### Summary
Limit channel name size on push proxy to avoid potential "Payload too large" errors.

#### Ticket Link
NONE
