### PR TITLE
Add retries to notification calls

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ const (
 	HEADER_REAL_IP             = "X-Real-IP"
 	WAIT_FOR_SERVER_SHUTDOWN   = time.Second * 5
 	CONNECTION_TIMEOUT_SECONDS = 60
+	MAX_RETRIES                = 3
 )
 
 type NotificationServer interface {


### PR DESCRIPTION
#### Summary
We have seen several errors that seem to be network hiccups. To avoid missing notifications, we add a retry logic whenever an unexpected error appears.

This may result on duplicated notifications, but we prefer to err on the safe side, instead of having missed notifications.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-56827

