### PR TITLE
Increase redaction of deviceId from 8 to 16 chars

### DIFF
--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -3,13 +3,13 @@
 
 package server
 
-// redactToken returns the first 8 chars of a device token followed by an
+// redactToken returns the first 16 chars of a device token followed by an
 // ellipsis, for safe inclusion in logs.
 func redactToken(token string) string {
-	if len(token) <= 8 {
+	if len(token) <= 16 {
 		return token
 	}
-	return token[:8] + "…"
+	return token[:16] + "…"
 }
 
 const (

--- a/server/push_notification_test.go
+++ b/server/push_notification_test.go
@@ -17,9 +17,9 @@ func TestRedactToken(t *testing.T) {
 	}{
 		{"empty", "", ""},
 		{"short token passes through", "1234", "1234"},
-		{"8 chars passes through", "12345678", "12345678"},
-		{"9 chars truncated", "123456789", "12345678…"},
-		{"long token truncated", "abcdef0123456789cafebabe", "abcdef01…"},
+		{"16 chars passes through", "0123456789abcdef", "0123456789abcdef"},
+		{"17 chars truncated", "0123456789abcdefg", "0123456789abcdef…"},
+		{"long token truncated", "abcdef0123456789cafebabe1234", "abcdef0123456789…"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, redactToken(tc.token))


### PR DESCRIPTION
#### Summary
This PR updates the redact of a deviceId from 8 to 16 chars.
