### PR TITLE
fix divergent BASE_IMAGE_FIPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ DOCKER_IMAGE_GH_CLI     ?= "ghcr.io/supportpal/github-gh-cli:2.31.0@sha256:71371
 # Requires Docker to be installed and running
 FIPS_ENABLED ?= false
 BUILD_IMAGE_FIPS ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3
-BASE_IMAGE_FIPS ?= cgr.dev/mattermost.com/glibc-openssl-fips:15.1
+BASE_IMAGE_FIPS ?= cgr.dev/mattermost.com/glibc-openssl-fips:15.2
 
 ## Cosign Variables
 # The public key


### PR DESCRIPTION
## Summary

Bumps `BASE_IMAGE_FIPS` in the `Makefile` from `cgr.dev/mattermost.com/glibc-openssl-fips:15.1` to `15.2` to fix a divergent value.

#150 ("Make image versioning consistent") bumped the FIPS base image to `15.2` in `docker/Dockerfile.fips`, but missed the corresponding `BASE_IMAGE_FIPS` default in the `Makefile`, which stayed at `15.1`. As a result the two pinned versions diverged. This restores consistency between them.