### PR TITLE
Drop FIPS arm64 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,28 +103,6 @@ jobs:
       - name: Build FIPS Docker Image for AMD64
         run: make build-image-fips-amd64-with-tags
 
-  fips-build-arm64:
-    name: FIPS Build ARM64
-    runs-on: ubuntu-24.04-arm
-    needs: [lint, test]
-    if: github.actor != 'dependabot[bot]'
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup Chainguard
-        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
-        with:
-          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
-
-      - name: Build FIPS Docker Image for ARM64
-        run: make build-image-fips-arm64-with-tags
 
   fips-security-scan:
     name: FIPS Security Scan
@@ -310,48 +288,10 @@ jobs:
           docker push mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64
           echo "✅ FIPS AMD64 image pushed: mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64"
 
-  pr-deploy-fips-arm64:
-    name: PR Deploy FIPS ARM64
-    runs-on: ubuntu-24.04-arm
-    needs: [fips-security-scan, fips-build-arm64]
-    if: github.event_name == 'pull_request' && github.repository_owner == 'mattermost' && github.actor != 'dependabot[bot]'
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup Chainguard Identity
-        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
-        with:
-          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          username: matterbuild
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push FIPS ARM64 PR images
-        run: |
-          # Build with default APP_NAME (avoids filesystem issues)
-          make build-image-fips-arm64-with-tags
-
-          # Retag with correct namespace for pushing
-          docker tag mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64 mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64
-          docker tag mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }} mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}
-
-          # Push to correct namespace
-          docker push mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64
-          echo "✅ FIPS ARM64 image pushed: mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64"
-
   pr-deploy-fips-manifest:
     name: PR Deploy FIPS Manifest
     runs-on: ubuntu-latest
-    needs: [pr-deploy-fips-amd64, pr-deploy-fips-arm64]
+    needs: [pr-deploy-fips-amd64]
     if: github.event_name == 'pull_request' && github.repository_owner == 'mattermost' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
@@ -363,19 +303,12 @@ jobs:
           username: matterbuild
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create and push FIPS multi-arch manifest
+      - name: Push FIPS image with final tag
         run: |
-          # Create multi-platform FIPS manifest for PR testing
-          docker manifest create mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }} \
-            --amend mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64 \
-            --amend mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64
-          docker manifest push mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}
-
-          # Clean up intermediate FIPS architecture-specific tags (like production)
-          echo "Cleaning up intermediate FIPS architecture-specific tags..."
-          docker rmi mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64 2>/dev/null || true
-          docker rmi mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-arm64 2>/dev/null || true
-          echo "✅ Multi-arch FIPS PR image available (arch-specific tags removed):"
+          docker pull mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64
+          docker tag mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}-amd64 mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}
+          docker push mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}
+          echo "✅ FIPS PR image available:"
           echo "  docker pull mattermost/mattermost-push-proxy-fips:dev-${{ github.sha }}"
 
   deploy-amd64:
@@ -537,45 +470,10 @@ jobs:
           # Push temp FIPS AMD64 image
           docker push mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-amd64
 
-  fips-deploy-arm64:
-    name: FIPS Deploy ARM64
-    runs-on: ubuntu-24.04-arm
-    needs: [fips-security-scan, fips-build-arm64]
-    if: github.repository_owner == 'mattermost' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Setup Chainguard Identity
-        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
-        with:
-          identity: ${{ secrets.CHAINGUARD_IDENTITY }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          username: matterbuild
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push FIPS ARM64 image
-        run: |
-          # Build FIPS ARM64 image with temp tag for cleanup
-          SHORT_SHA=${GITHUB_SHA:0:7}
-          make build-image-fips-arm64-with-tags
-          # Retag with temp namespace for later cleanup
-          docker tag mattermost/mattermost-push-proxy-fips:master-arm64 mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-arm64
-          # Push temp FIPS ARM64 image
-          docker push mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-arm64
-
   fips-deploy:
     name: FIPS Deploy
     runs-on: ubuntu-latest
-    needs: [fips-deploy-amd64, fips-deploy-arm64]
+    needs: [fips-deploy-amd64]
     if: github.repository_owner == 'mattermost' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
     permissions:
       contents: write
@@ -592,43 +490,25 @@ jobs:
           username: matterbuild
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create and push FIPS multi-arch manifest
+      - name: Push FIPS image with final tag
         run: |
-          # Create multi-platform manifest for FIPS using commit SHA
           SHORT_SHA=${GITHUB_SHA:0:7}
-          docker manifest create mattermost/mattermost-push-proxy-fips:${SHORT_SHA} \
-            --amend mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-amd64 \
-            --amend mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-arm64
-          docker manifest push mattermost/mattermost-push-proxy-fips:${SHORT_SHA}
+          docker pull mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-amd64
+          docker tag mattermost/mattermost-push-proxy-fips:temp-${GITHUB_SHA}-amd64 mattermost/mattermost-push-proxy-fips:${SHORT_SHA}
+          docker push mattermost/mattermost-push-proxy-fips:${SHORT_SHA}
 
-          echo "✅ Clean unified FIPS multi-arch tag: mattermost/mattermost-push-proxy-fips:${SHORT_SHA}"
+          echo "✅ FIPS image pushed: mattermost/mattermost-push-proxy-fips:${SHORT_SHA}"
 
-          # Cleanup temp FIPS tags using Docker Hub API
-          echo "🗑️  Cleaning up temp FIPS tags from Docker Hub..."
-
-          # Delete temp FIPS tags using Docker Hub API
-          TEMP_AMD64_TAG="temp-${GITHUB_SHA}-amd64"
-          TEMP_ARM64_TAG="temp-${GITHUB_SHA}-arm64"
-
-          # Get Docker Hub API token using org-level cleanup token
+          # Cleanup temp FIPS tag using Docker Hub API
           DOCKER_HUB_TOKEN=$(curl -s -X POST \
             -H "Content-Type: application/json" \
             -d '{"username": "matterbuild", "password": "${{ secrets.DOCKERHUB_CLEANUP_TOKEN }}"}' \
             https://hub.docker.com/v2/users/login/ | jq -r .token)
 
-          # Delete FIPS AMD64 temp tag
           curl -X DELETE \
             -H "Authorization: JWT ${DOCKER_HUB_TOKEN}" \
-            "https://hub.docker.com/v2/repositories/mattermost/mattermost-push-proxy-fips/tags/${TEMP_AMD64_TAG}/" \
-            && echo "✅ Deleted FIPS AMD64 temp tag" || echo "⚠️  FIPS AMD64 temp tag not found or already deleted"
-
-          # Delete FIPS ARM64 temp tag
-          curl -X DELETE \
-            -H "Authorization: JWT ${DOCKER_HUB_TOKEN}" \
-            "https://hub.docker.com/v2/repositories/mattermost/mattermost-push-proxy-fips/tags/${TEMP_ARM64_TAG}/" \
-            && echo "✅ Deleted FIPS ARM64 temp tag" || echo "⚠️  FIPS ARM64 temp tag not found or already deleted"
-
-          echo "✅ Temp FIPS tags cleaned up from Docker Hub"
+            "https://hub.docker.com/v2/repositories/mattermost/mattermost-push-proxy-fips/tags/temp-${GITHUB_SHA}-amd64/" \
+            && echo "✅ Deleted FIPS temp tag" || echo "⚠️  FIPS temp tag not found or already deleted"
 
       - name: Create FIPS release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,6 @@ jobs:
     if: github.event_name == 'pull_request' && github.repository_owner == 'mattermost' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0


### PR DESCRIPTION
## Summary

Following up on https://hub.mattermost.com/private-core/pl/o1fdywhwi7dazdqytzi4e46iga to remove FIPS support for ARM64. (For now, we'll still build and ship ARM64, but no need to support that particular matrix combination.)