### PR TITLE
Rework logging: gate levels, add throughput heartbeat, standardize fields

### DIFF
--- a/config/mattermost-push-proxy.sample.json
+++ b/config/mattermost-push-proxy.sample.json
@@ -41,5 +41,6 @@
     "EnableConsoleLog": true,
     "EnableFileLog": false,
     "LogFileLocation": "",
-    "LogFormat": "plain"
+    "LogFormat": "plain",
+    "LogLevel": "info"
 }

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -46,6 +46,10 @@ type AndroidNotificationServer struct {
 	client              *messaging.Client
 	sendTimeout         time.Duration
 	retryTimeout        time.Duration
+	// validateToken mints an OAuth2 token from the service account to verify
+	// the credentials are still accepted by Google. It is nil until a service
+	// account has been loaded in Initialize.
+	validateToken func(context.Context) error
 }
 
 // serviceAccount contains a subset of the fields in service-account.json.
@@ -97,6 +101,11 @@ func (me *AndroidNotificationServer) Initialize() error {
 		return fmt.Errorf("error parsing service account JSON: %v", err)
 	}
 
+	me.validateToken = func(ctx context.Context) error {
+		_, tErr := cfg.TokenSource(ctx).Token()
+		return tErr
+	}
+
 	opt := option.WithTokenSource(cfg.TokenSource(context.Background()))
 	conf := &firebase.Config{
 		ProjectID:        serviceAcc.ProjectID,
@@ -114,6 +123,27 @@ func (me *AndroidNotificationServer) Initialize() error {
 	me.client = client
 
 	return nil
+}
+
+// checkCredentialExpiry validates the FCM service account credentials by
+// minting an OAuth2 token. The service account key carries no readable expiry,
+// so this actively probes whether the key is still accepted (it fails once the
+// key is revoked, disabled, or deleted) and logs an Error to alert on.
+func (me *AndroidNotificationServer) checkCredentialExpiry() {
+	if me.validateToken == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), me.sendTimeout)
+	defer cancel()
+
+	if err := me.validateToken(ctx); err != nil {
+		me.logger.Error(
+			"FCM credentials rejected; the service account key may be revoked, disabled, or expired",
+			mlog.String("target_type", me.AndroidPushSettings.Type),
+			mlog.Err(err),
+		)
+	}
 }
 
 func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNotification) PushResponse {

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -40,6 +40,7 @@ const (
 
 type AndroidNotificationServer struct {
 	metrics             *metrics
+	stats               *stats
 	logger              *mlog.Logger
 	AndroidPushSettings AndroidPushSettings
 	client              *messaging.Client
@@ -58,10 +59,11 @@ type serviceAccount struct {
 	TokenURI    string `json:"token_uri"`
 }
 
-func NewAndroidNotificationServer(settings AndroidPushSettings, logger *mlog.Logger, metrics *metrics, sendTimeoutSecs int, retryTimeoutSecs int) *AndroidNotificationServer {
+func NewAndroidNotificationServer(settings AndroidPushSettings, logger *mlog.Logger, metrics *metrics, stats *stats, sendTimeoutSecs int, retryTimeoutSecs int) *AndroidNotificationServer {
 	return &AndroidNotificationServer{
 		AndroidPushSettings: settings,
 		metrics:             metrics,
+		stats:               stats,
 		logger:              logger,
 		sendTimeout:         time.Duration(sendTimeoutSecs) * time.Second,
 		retryTimeout:        time.Duration(retryTimeoutSecs) * time.Second,
@@ -69,10 +71,10 @@ func NewAndroidNotificationServer(settings AndroidPushSettings, logger *mlog.Log
 }
 
 func (me *AndroidNotificationServer) Initialize() error {
-	me.logger.Info("Initializing Android notification server", mlog.String("type", me.AndroidPushSettings.Type))
+	me.logger.Info("Initializing Android notification server", mlog.String("target_type", me.AndroidPushSettings.Type))
 
 	if me.AndroidPushSettings.AndroidAPIKey != "" {
-		me.logger.Info("AndroidPushSettings.AndroidAPIKey is no longer used. Please remove this config value.")
+		me.logger.Warn("AndroidPushSettings.AndroidAPIKey is no longer used. Please remove this config value.")
 	}
 
 	if me.AndroidPushSettings.ServiceFileLocation == "" {
@@ -171,10 +173,11 @@ func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNoti
 		},
 	}
 
-	me.logger.Info(
+	me.stats.incrementAndroidSend()
+	me.logger.Debug(
 		"Sending android push notification",
-		mlog.String("device", me.AndroidPushSettings.Type),
-		mlog.String("type", msg.Type),
+		mlog.String("target_type", me.AndroidPushSettings.Type),
+		mlog.String("push_type", msg.Type),
 		mlog.String("ack_id", msg.AckId),
 	)
 	err := me.SendNotificationWithRetry(fcmMsg)
@@ -186,15 +189,15 @@ func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNoti
 
 		me.logger.Error(
 			"Failed to send FCM push",
-			mlog.String("sid", msg.ServerId),
-			mlog.String("did", redactToken(msg.DeviceId)),
+			mlog.String("server_id", msg.ServerId),
+			mlog.String("device_id", redactToken(msg.DeviceId)),
 			mlog.Err(err),
-			mlog.String("type", me.AndroidPushSettings.Type),
-			mlog.String("errorCode", errorCode),
+			mlog.String("target_type", me.AndroidPushSettings.Type),
+			mlog.String("error_code", errorCode),
 		)
 
 		if messaging.IsUnregistered(err) || messaging.IsSenderIDMismatch(err) {
-			me.logger.Info("Android response failure sending remove code", mlog.String("type", me.AndroidPushSettings.Type))
+			me.logger.Info("Android response failure sending remove code", mlog.String("target_type", me.AndroidPushSettings.Type))
 			if me.metrics != nil {
 				me.metrics.incrementRemoval(model.PushNotifyAndroid, pushType, model.PushTransportStandard, unregistered)
 			}
@@ -238,7 +241,7 @@ func (me *AndroidNotificationServer) SendNotificationWithRetry(fcmMsg *messaging
 	var err error
 	waitTime := time.Second
 
-	logger := me.logger.With(mlog.String("did", redactToken(fcmMsg.Token)))
+	logger := me.logger.With(mlog.String("device_id", redactToken(fcmMsg.Token)))
 
 	// Keep a general context to make sure the whole retry
 	// doesn't take longer than the timeout.
@@ -259,14 +262,14 @@ func (me *AndroidNotificationServer) SendNotificationWithRetry(fcmMsg *messaging
 			break
 		}
 
-		logger.Error(
+		logger.Warn(
 			"Failed to send android push",
 			mlog.Int("retry", retries),
 			mlog.Err(err),
 		)
 
 		if retries == MAX_RETRIES-1 {
-			logger.Error("Max retries reached")
+			logger.Warn("Max retries reached")
 			break
 		}
 

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -137,13 +137,27 @@ func (me *AndroidNotificationServer) checkCredentialExpiry() {
 	ctx, cancel := context.WithTimeout(context.Background(), me.sendTimeout)
 	defer cancel()
 
-	if err := me.validateToken(ctx); err != nil {
-		me.logger.Error(
-			"FCM credentials rejected; the service account key may be revoked, disabled, or expired",
+	err := me.validateToken(ctx)
+	if err == nil {
+		return
+	}
+
+	// A timeout is a transient/network problem, not evidence the key itself is
+	// bad, so keep it out of Error to avoid false credential alerts.
+	if errors.Is(err, context.DeadlineExceeded) {
+		me.logger.Warn(
+			"FCM credential check timed out; could not verify the service account key",
 			mlog.String("target_type", me.AndroidPushSettings.Type),
 			mlog.Err(err),
 		)
+		return
 	}
+
+	me.logger.Error(
+		"FCM credentials rejected; the service account key may be revoked, disabled, or expired",
+		mlog.String("target_type", me.AndroidPushSettings.Type),
+		mlog.Err(err),
+	)
 }
 
 func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNotification) PushResponse {

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -212,6 +212,22 @@ func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNoti
 	)
 	err := me.SendNotificationWithRetry(fcmMsg)
 	if err != nil {
+		// An unregistered or mismatched token is a client-driven condition, not
+		// a server fault: log it at Warn and route through the removal branch.
+		if messaging.IsUnregistered(err) || messaging.IsSenderIDMismatch(err) {
+			me.logger.Warn(
+				"Android response failure sending remove code",
+				mlog.String("server_id", msg.ServerId),
+				mlog.String("device_id", redactToken(msg.DeviceId)),
+				mlog.String("target_type", me.AndroidPushSettings.Type),
+				mlog.Err(err),
+			)
+			if me.metrics != nil {
+				me.metrics.incrementRemoval(model.PushNotifyAndroid, pushType, model.PushTransportStandard, unregistered)
+			}
+			return NewRemovePushResponse()
+		}
+
 		errorCode, hasStatusCode := getErrorCode(err)
 		if !hasStatusCode {
 			errorCode = "NONE"
@@ -225,14 +241,6 @@ func (me *AndroidNotificationServer) SendNotification(_ int, msg *model.PushNoti
 			mlog.String("target_type", me.AndroidPushSettings.Type),
 			mlog.String("error_code", errorCode),
 		)
-
-		if messaging.IsUnregistered(err) || messaging.IsSenderIDMismatch(err) {
-			me.logger.Info("Android response failure sending remove code", mlog.String("target_type", me.AndroidPushSettings.Type))
-			if me.metrics != nil {
-				me.metrics.incrementRemoval(model.PushNotifyAndroid, pushType, model.PushTransportStandard, unregistered)
-			}
-			return NewRemovePushResponse()
-		}
 
 		var reason string
 		switch {

--- a/server/android_notification_test.go
+++ b/server/android_notification_test.go
@@ -4,12 +4,15 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -65,6 +68,38 @@ type FirebaseError struct {
 
 func (fe *FirebaseError) Error() string {
 	return fe.String
+}
+
+func TestAndroidCheckCredentialExpiry(t *testing.T) {
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	t.Run("invokes the token validator", func(t *testing.T) {
+		var gotCtx context.Context
+		me := &AndroidNotificationServer{
+			AndroidPushSettings: AndroidPushSettings{Type: "android"},
+			logger:              logger,
+			sendTimeout:         time.Second,
+			validateToken: func(ctx context.Context) error {
+				gotCtx = ctx
+				return errors.New("service account key revoked")
+			},
+		}
+
+		assert.NotPanics(t, me.checkCredentialExpiry)
+		require.NotNil(t, gotCtx, "validateToken should have been called")
+		_, hasDeadline := gotCtx.Deadline()
+		assert.True(t, hasDeadline, "validation should be bounded by sendTimeout")
+	})
+
+	t.Run("no validator is a no-op", func(t *testing.T) {
+		me := &AndroidNotificationServer{
+			AndroidPushSettings: AndroidPushSettings{Type: "android"},
+			logger:              logger,
+		}
+		assert.Nil(t, me.validateToken)
+		assert.NotPanics(t, me.checkCredentialExpiry)
+	})
 }
 
 func TestGetErrorCode(t *testing.T) {

--- a/server/android_notification_test.go
+++ b/server/android_notification_test.go
@@ -71,28 +71,28 @@ func (fe *FirebaseError) Error() string {
 }
 
 func TestAndroidCheckCredentialExpiry(t *testing.T) {
-	logger, err := mlog.NewLogger()
-	require.NoError(t, err)
-
-	t.Run("invokes the token validator", func(t *testing.T) {
-		var gotCtx context.Context
+	t.Run("logs Error when credentials are rejected", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
 		me := &AndroidNotificationServer{
 			AndroidPushSettings: AndroidPushSettings{Type: "android"},
 			logger:              logger,
 			sendTimeout:         time.Second,
-			validateToken: func(ctx context.Context) error {
-				gotCtx = ctx
+			validateToken: func(_ context.Context) error {
 				return errors.New("service account key revoked")
 			},
 		}
 
-		assert.NotPanics(t, me.checkCredentialExpiry)
-		require.NotNil(t, gotCtx, "validateToken should have been called")
-		_, hasDeadline := gotCtx.Deadline()
-		assert.True(t, hasDeadline, "validation should be bounded by sendTimeout")
+		me.checkCredentialExpiry()
+
+		records := flushLogs(t, logger, buf)
+		require.Len(t, records, 1)
+		assert.Equal(t, "error", records[0]["level"])
+		assert.Contains(t, records[0]["msg"], "FCM credentials rejected")
+		assert.Equal(t, "android", records[0]["target_type"])
 	})
 
-	t.Run("timeout is handled without panicking", func(t *testing.T) {
+	t.Run("logs Warn on timeout", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
 		me := &AndroidNotificationServer{
 			AndroidPushSettings: AndroidPushSettings{Type: "android"},
 			logger:              logger,
@@ -101,16 +101,45 @@ func TestAndroidCheckCredentialExpiry(t *testing.T) {
 				return context.DeadlineExceeded
 			},
 		}
-		assert.NotPanics(t, me.checkCredentialExpiry)
+
+		me.checkCredentialExpiry()
+
+		records := flushLogs(t, logger, buf)
+		require.Len(t, records, 1)
+		assert.Equal(t, "warn", records[0]["level"])
+		assert.Contains(t, records[0]["msg"], "timed out")
+	})
+
+	t.Run("validates with a bounded context and stays silent on success", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		var hasDeadline bool
+		me := &AndroidNotificationServer{
+			AndroidPushSettings: AndroidPushSettings{Type: "android"},
+			logger:              logger,
+			sendTimeout:         time.Second,
+			validateToken: func(ctx context.Context) error {
+				_, hasDeadline = ctx.Deadline()
+				return nil
+			},
+		}
+
+		me.checkCredentialExpiry()
+
+		assert.True(t, hasDeadline, "validation should be bounded by sendTimeout")
+		assert.Empty(t, flushLogs(t, logger, buf), "successful validation should not log")
 	})
 
 	t.Run("no validator is a no-op", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
 		me := &AndroidNotificationServer{
 			AndroidPushSettings: AndroidPushSettings{Type: "android"},
 			logger:              logger,
 		}
+
+		me.checkCredentialExpiry()
+
 		assert.Nil(t, me.validateToken)
-		assert.NotPanics(t, me.checkCredentialExpiry)
+		assert.Empty(t, flushLogs(t, logger, buf))
 	})
 }
 

--- a/server/android_notification_test.go
+++ b/server/android_notification_test.go
@@ -92,6 +92,18 @@ func TestAndroidCheckCredentialExpiry(t *testing.T) {
 		assert.True(t, hasDeadline, "validation should be bounded by sendTimeout")
 	})
 
+	t.Run("timeout is handled without panicking", func(t *testing.T) {
+		me := &AndroidNotificationServer{
+			AndroidPushSettings: AndroidPushSettings{Type: "android"},
+			logger:              logger,
+			sendTimeout:         time.Second,
+			validateToken: func(_ context.Context) error {
+				return context.DeadlineExceeded
+			},
+		}
+		assert.NotPanics(t, me.checkCredentialExpiry)
+	})
+
 	t.Run("no validator is a no-op", func(t *testing.T) {
 		me := &AndroidNotificationServer{
 			AndroidPushSettings: AndroidPushSettings{Type: "android"},

--- a/server/android_notification_test.go
+++ b/server/android_notification_test.go
@@ -26,7 +26,7 @@ func TestAndroidInitialize(t *testing.T) {
 	// Verify error for no service file
 	pushSettings := AndroidPushSettings{}
 	cfg.AndroidPushSettings[0] = pushSettings
-	require.Error(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
+	require.Error(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
 
 	f, err := os.CreateTemp("", "example")
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestAndroidInitialize(t *testing.T) {
 	// Verify error for bad JSON
 	_, err = f.Write([]byte("badJSON"))
 	require.NoError(t, err)
-	require.Error(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
+	require.Error(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
 
 	require.NoError(t, f.Truncate(0))
 	_, err = f.Seek(0, 0)
@@ -49,7 +49,7 @@ func TestAndroidInitialize(t *testing.T) {
 		ProjectID: "sample",
 	}))
 	require.NoError(t, f.Sync())
-	require.NoError(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
+	require.NoError(t, NewAndroidNotificationServer(cfg.AndroidPushSettings[0], logger, nil, nil, cfg.SendTimeoutSec, cfg.RetryTimeoutSec).Initialize())
 
 	require.NoError(t, f.Close())
 }

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -25,16 +25,18 @@ import (
 type AppleNotificationServer struct {
 	AppleClient       *apns.Client
 	metrics           *metrics
+	stats             *stats
 	logger            *mlog.Logger
 	ApplePushSettings ApplePushSettings
 	sendTimeout       time.Duration
 	retryTimeout      time.Duration
 }
 
-func NewAppleNotificationServer(settings ApplePushSettings, logger *mlog.Logger, metrics *metrics, sendTimeoutSecs int, retryTimeoutSecs int) *AppleNotificationServer {
+func NewAppleNotificationServer(settings ApplePushSettings, logger *mlog.Logger, metrics *metrics, stats *stats, sendTimeoutSecs int, retryTimeoutSecs int) *AppleNotificationServer {
 	return &AppleNotificationServer{
 		ApplePushSettings: settings,
 		metrics:           metrics,
+		stats:             stats,
 		logger:            logger,
 		sendTimeout:       time.Duration(sendTimeoutSecs) * time.Second,
 		retryTimeout:      time.Duration(retryTimeoutSecs) * time.Second,
@@ -67,9 +69,9 @@ func (me *AppleNotificationServer) setupProxySettings(appleCert *tls.Certificate
 	}
 
 	if appleCert != nil {
-		me.logger.Info("Initializing apple notification server with PEM certificate", mlog.String("type", me.ApplePushSettings.Type))
+		me.logger.Info("Initializing apple notification server with PEM certificate", mlog.String("target_type", me.ApplePushSettings.Type))
 	} else {
-		me.logger.Info("Initializing apple notification server with AuthKey", mlog.String("type", me.ApplePushSettings.Type))
+		me.logger.Info("Initializing apple notification server with AuthKey", mlog.String("target_type", me.ApplePushSettings.Type))
 	}
 
 	return nil
@@ -242,22 +244,23 @@ func (me *AppleNotificationServer) dispatchAndHandleResponse(notification *apns.
 	}
 
 	logFields := []mlog.Field{
-		mlog.String("device", me.ApplePushSettings.Type),
-		mlog.String("type", msg.Type),
+		mlog.String("target_type", me.ApplePushSettings.Type),
+		mlog.String("push_type", msg.Type),
 		mlog.String("ack_id", msg.AckId),
 	}
 	if transport != model.PushTransportStandard {
 		logFields = append(logFields, mlog.String("transport", string(transport)))
 	}
-	me.logger.Info("Sending apple push notification", logFields...)
+	me.stats.incrementAppleSend()
+	me.logger.Debug("Sending apple push notification", logFields...)
 
 	res, err := me.SendNotificationWithRetry(notification)
 	if err != nil {
 		errFields := []mlog.Field{
-			mlog.String("sid", msg.ServerId),
-			mlog.String("did", redactToken(msg.DeviceId)),
+			mlog.String("server_id", msg.ServerId),
+			mlog.String("device_id", redactToken(msg.DeviceId)),
 			mlog.Err(err),
-			mlog.String("type", me.ApplePushSettings.Type),
+			mlog.String("target_type", me.ApplePushSettings.Type),
 		}
 		if transport != model.PushTransportStandard {
 			errFields = append(errFields, mlog.String("transport", string(transport)))
@@ -273,10 +276,10 @@ func (me *AppleNotificationServer) dispatchAndHandleResponse(notification *apns.
 		if res.Reason == apns.ReasonBadDeviceToken || res.Reason == apns.ReasonUnregistered || res.Reason == apns.ReasonMissingDeviceToken || res.Reason == apns.ReasonDeviceTokenNotForTopic {
 			me.logger.Info(
 				"Failed to send apple push sending remove code res",
-				mlog.String("ApnsID", res.ApnsID),
+				mlog.String("apns_id", res.ApnsID),
 				mlog.String("reason", res.Reason),
 				mlog.Int("code", res.StatusCode),
-				mlog.String("type", me.ApplePushSettings.Type),
+				mlog.String("target_type", me.ApplePushSettings.Type),
 			)
 			if me.metrics != nil {
 				me.metrics.incrementRemoval(model.PushNotifyApple, pushType, transport, res.Reason)
@@ -286,10 +289,10 @@ func (me *AppleNotificationServer) dispatchAndHandleResponse(notification *apns.
 
 		me.logger.Error(
 			"Failed to send apple push with res",
-			mlog.String("ApnsID", res.ApnsID),
+			mlog.String("apns_id", res.ApnsID),
 			mlog.String("reason", res.Reason),
 			mlog.Int("code", res.StatusCode),
-			mlog.String("type", me.ApplePushSettings.Type),
+			mlog.String("target_type", me.ApplePushSettings.Type),
 		)
 		if me.metrics != nil {
 			me.metrics.incrementFailure(model.PushNotifyApple, pushType, transport, res.Reason)
@@ -389,15 +392,15 @@ func (me *AppleNotificationServer) SendNotificationWithRetry(notification *apns.
 			break
 		}
 
-		me.logger.Error(
+		me.logger.Warn(
 			"Failed to send apple push",
-			mlog.String("did", redactToken(notification.DeviceToken)),
+			mlog.String("device_id", redactToken(notification.DeviceToken)),
 			mlog.Int("retry", retries),
 			mlog.Err(err),
 		)
 
 		if retries == MAX_RETRIES-1 {
-			me.logger.Error("Max retries reached", mlog.String("did", redactToken(notification.DeviceToken)))
+			me.logger.Warn("Max retries reached", mlog.String("device_id", redactToken(notification.DeviceToken)))
 			break
 		}
 
@@ -409,7 +412,7 @@ func (me *AppleNotificationServer) SendNotificationWithRetry(notification *apns.
 		if generalContext.Err() != nil {
 			me.logger.Info(
 				"Not retrying because context error",
-				mlog.String("did", redactToken(notification.DeviceToken)),
+				mlog.String("device_id", redactToken(notification.DeviceToken)),
 				mlog.Int("retry", retries),
 				mlog.Err(generalContext.Err()),
 			)

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -22,6 +23,35 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
+// Thresholds for how much validity remains before the Apple push certificate
+// expiry is logged, so it can be alerted on ahead of an outage.
+const (
+	certExpiryWarnThreshold  = 30 * 24 * time.Hour
+	certExpiryErrorThreshold = 7 * 24 * time.Hour
+)
+
+type expiryStatus int
+
+const (
+	expiryOK expiryStatus = iota
+	expiryWarn
+	expiryError
+)
+
+// certExpiryStatus classifies how urgently a certificate needs rotation based
+// on the time remaining until it expires. A non-positive duration (already
+// expired) falls into expiryError.
+func certExpiryStatus(timeLeft time.Duration) expiryStatus {
+	switch {
+	case timeLeft <= certExpiryErrorThreshold:
+		return expiryError
+	case timeLeft <= certExpiryWarnThreshold:
+		return expiryWarn
+	default:
+		return expiryOK
+	}
+}
+
 type AppleNotificationServer struct {
 	AppleClient       *apns.Client
 	metrics           *metrics
@@ -30,6 +60,9 @@ type AppleNotificationServer struct {
 	ApplePushSettings ApplePushSettings
 	sendTimeout       time.Duration
 	retryTimeout      time.Duration
+	// certNotAfter is the expiry of the loaded push certificate. It is the
+	// zero value for token (AuthKey) auth, which does not expire.
+	certNotAfter time.Time
 }
 
 func NewAppleNotificationServer(settings ApplePushSettings, logger *mlog.Logger, metrics *metrics, stats *stats, sendTimeoutSecs int, retryTimeoutSecs int) *AppleNotificationServer {
@@ -106,6 +139,8 @@ func (me *AppleNotificationServer) Initialize() error {
 			return fmt.Errorf("failed to initialize apple notification service with pem cert err=%v for type=%v", appleCertErr, me.ApplePushSettings.Type)
 		}
 
+		me.certNotAfter = certNotAfter(appleCert)
+
 		if me.ApplePushSettings.ApplePushUseDevelopment {
 			me.AppleClient = apns.NewClient(appleCert).Development()
 		} else {
@@ -117,6 +152,44 @@ func (me *AppleNotificationServer) Initialize() error {
 	}
 
 	return fmt.Errorf("apple push notifications not configured: missing ApplePushCertPrivate for type=%v", me.ApplePushSettings.Type)
+}
+
+// certNotAfter returns the expiry of the leaf certificate, or the zero time if
+// it cannot be determined.
+func certNotAfter(cert tls.Certificate) time.Time {
+	if cert.Leaf != nil {
+		return cert.Leaf.NotAfter
+	}
+	if len(cert.Certificate) > 0 {
+		if parsed, err := x509.ParseCertificate(cert.Certificate[0]); err == nil {
+			return parsed.NotAfter
+		}
+	}
+	return time.Time{}
+}
+
+// checkCredentialExpiry logs a Warn/Error as the push certificate nears
+// expiry, so operators can alert on it before deliveries start failing.
+// Token (AuthKey) auth has no expiry and is a no-op.
+func (me *AppleNotificationServer) checkCredentialExpiry() {
+	if me.certNotAfter.IsZero() {
+		return
+	}
+
+	timeLeft := time.Until(me.certNotAfter)
+	fields := []mlog.Field{
+		mlog.String("target_type", me.ApplePushSettings.Type),
+		mlog.Time("expires_at", me.certNotAfter),
+		mlog.Duration("time_left", timeLeft),
+	}
+
+	switch certExpiryStatus(timeLeft) {
+	case expiryError:
+		me.logger.Error("Apple push certificate is expiring soon or has expired", fields...)
+	case expiryWarn:
+		me.logger.Warn("Apple push certificate is expiring soon", fields...)
+	case expiryOK:
+	}
 }
 
 func (me *AppleNotificationServer) SendNotification(appVersion int, msg *model.PushNotification) PushResponse {

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -30,25 +30,36 @@ const (
 	certExpiryErrorThreshold = 7 * 24 * time.Hour
 )
 
-type expiryStatus int
+type expiryLevel int
 
 const (
-	expiryOK expiryStatus = iota
+	expiryNone expiryLevel = iota
 	expiryWarn
 	expiryError
 )
 
-// certExpiryStatus classifies how urgently a certificate needs rotation based
-// on the time remaining until it expires. A non-positive duration (already
-// expired) falls into expiryError.
-func certExpiryStatus(timeLeft time.Duration) expiryStatus {
-	switch {
+// certExpiryReport decides how a certificate's expiry should be reported. It
+// disambiguates the cases operators care about: a certificate that has already
+// expired vs. one nearing expiry, and a certificate whose expiry could not be
+// determined (notAfter zero while hasCert is true) vs. token auth that has no
+// certificate at all (hasCert false), which never expires.
+func certExpiryReport(hasCert bool, notAfter, now time.Time) (expiryLevel, string) {
+	if notAfter.IsZero() {
+		if hasCert {
+			return expiryWarn, "Could not determine Apple push certificate expiry"
+		}
+		return expiryNone, ""
+	}
+
+	switch timeLeft := notAfter.Sub(now); {
+	case timeLeft <= 0:
+		return expiryError, "Apple push certificate has expired"
 	case timeLeft <= certExpiryErrorThreshold:
-		return expiryError
+		return expiryError, "Apple push certificate is expiring soon"
 	case timeLeft <= certExpiryWarnThreshold:
-		return expiryWarn
+		return expiryWarn, "Apple push certificate is expiring soon"
 	default:
-		return expiryOK
+		return expiryNone, ""
 	}
 }
 
@@ -60,8 +71,11 @@ type AppleNotificationServer struct {
 	ApplePushSettings ApplePushSettings
 	sendTimeout       time.Duration
 	retryTimeout      time.Duration
-	// certNotAfter is the expiry of the loaded push certificate. It is the
-	// zero value for token (AuthKey) auth, which does not expire.
+	// hasCert reports whether certificate auth is in use. Token (AuthKey) auth
+	// has no certificate and never expires.
+	hasCert bool
+	// certNotAfter is the expiry of the loaded push certificate. It is the zero
+	// value for token auth, or when the expiry could not be parsed.
 	certNotAfter time.Time
 }
 
@@ -139,6 +153,7 @@ func (me *AppleNotificationServer) Initialize() error {
 			return fmt.Errorf("failed to initialize apple notification service with pem cert err=%v for type=%v", appleCertErr, me.ApplePushSettings.Type)
 		}
 
+		me.hasCert = true
 		me.certNotAfter = certNotAfter(appleCert)
 
 		if me.ApplePushSettings.ApplePushUseDevelopment {
@@ -168,27 +183,29 @@ func certNotAfter(cert tls.Certificate) time.Time {
 	return time.Time{}
 }
 
-// checkCredentialExpiry logs a Warn/Error as the push certificate nears
-// expiry, so operators can alert on it before deliveries start failing.
-// Token (AuthKey) auth has no expiry and is a no-op.
+// checkCredentialExpiry logs a Warn/Error as the push certificate nears expiry
+// (or once expired), so operators can alert on it before deliveries start
+// failing. Token (AuthKey) auth has no expiry and is a no-op.
 func (me *AppleNotificationServer) checkCredentialExpiry() {
-	if me.certNotAfter.IsZero() {
+	level, message := certExpiryReport(me.hasCert, me.certNotAfter, time.Now())
+	if level == expiryNone {
 		return
 	}
 
-	timeLeft := time.Until(me.certNotAfter)
-	fields := []mlog.Field{
-		mlog.String("target_type", me.ApplePushSettings.Type),
-		mlog.Time("expires_at", me.certNotAfter),
-		mlog.Duration("time_left", timeLeft),
+	fields := []mlog.Field{mlog.String("target_type", me.ApplePushSettings.Type)}
+	if !me.certNotAfter.IsZero() {
+		fields = append(fields,
+			mlog.Time("expires_at", me.certNotAfter),
+			mlog.Duration("time_left", time.Until(me.certNotAfter)),
+		)
 	}
 
-	switch certExpiryStatus(timeLeft) {
-	case expiryError:
-		me.logger.Error("Apple push certificate is expiring soon or has expired", fields...)
+	switch level {
 	case expiryWarn:
-		me.logger.Warn("Apple push certificate is expiring soon", fields...)
-	case expiryOK:
+		me.logger.Warn(message, fields...)
+	case expiryError:
+		me.logger.Error(message, fields...)
+	case expiryNone:
 	}
 }
 

--- a/server/apple_notification_test.go
+++ b/server/apple_notification_test.go
@@ -4,10 +4,18 @@
 package server
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	apns "github.com/sideshow/apns2"
 	"github.com/stretchr/testify/assert"
@@ -161,6 +169,78 @@ func TestBuildVoIPNotification(t *testing.T) {
 		assert.False(t, hasAck, "ack_id should not appear when not populated")
 	})
 
+}
+
+func TestCertExpiryStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		timeLeft time.Duration
+		want     expiryStatus
+	}{
+		{"plenty of validity", 90 * 24 * time.Hour, expiryOK},
+		{"just above warn threshold", certExpiryWarnThreshold + time.Hour, expiryOK},
+		{"at warn threshold", certExpiryWarnThreshold, expiryWarn},
+		{"within warn window", 20 * 24 * time.Hour, expiryWarn},
+		{"just above error threshold", certExpiryErrorThreshold + time.Hour, expiryWarn},
+		{"at error threshold", certExpiryErrorThreshold, expiryError},
+		{"within error window", 3 * 24 * time.Hour, expiryError},
+		{"already expired", -time.Hour, expiryError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, certExpiryStatus(tc.timeLeft))
+		})
+	}
+}
+
+func TestCertNotAfter(t *testing.T) {
+	notAfter := time.Now().Add(45 * 24 * time.Hour).Truncate(time.Second)
+	der := newTestCertDER(t, notAfter)
+
+	t.Run("uses populated leaf", func(t *testing.T) {
+		leaf, err := x509.ParseCertificate(der)
+		require.NoError(t, err)
+		got := certNotAfter(tls.Certificate{Leaf: leaf, Certificate: [][]byte{der}})
+		assert.WithinDuration(t, notAfter, got, time.Second)
+	})
+
+	t.Run("parses from DER when leaf is nil", func(t *testing.T) {
+		got := certNotAfter(tls.Certificate{Certificate: [][]byte{der}})
+		assert.WithinDuration(t, notAfter, got, time.Second)
+	})
+
+	t.Run("zero time when nothing to parse", func(t *testing.T) {
+		assert.True(t, certNotAfter(tls.Certificate{}).IsZero())
+	})
+}
+
+func newTestCertDER(t *testing.T, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test apns cert"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}
+
+func TestCheckCredentialExpiryNoCertIsNoop(t *testing.T) {
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	// Token (AuthKey) auth leaves certNotAfter at its zero value.
+	srv := &AppleNotificationServer{
+		ApplePushSettings: ApplePushSettings{Type: "apple"},
+		logger:            logger,
+	}
+
+	assert.True(t, srv.certNotAfter.IsZero())
+	assert.NotPanics(t, srv.checkCredentialExpiry)
 }
 
 func marshalPayload(t *testing.T, n *apns.Notification) map[string]any {

--- a/server/apple_notification_test.go
+++ b/server/apple_notification_test.go
@@ -171,23 +171,31 @@ func TestBuildVoIPNotification(t *testing.T) {
 
 }
 
-func TestCertExpiryStatus(t *testing.T) {
+func TestCertExpiryReport(t *testing.T) {
+	now := time.Now()
+
 	for _, tc := range []struct {
-		name     string
-		timeLeft time.Duration
-		want     expiryStatus
+		name        string
+		hasCert     bool
+		notAfter    time.Time
+		wantLevel   expiryLevel
+		wantMessage string
 	}{
-		{"plenty of validity", 90 * 24 * time.Hour, expiryOK},
-		{"just above warn threshold", certExpiryWarnThreshold + time.Hour, expiryOK},
-		{"at warn threshold", certExpiryWarnThreshold, expiryWarn},
-		{"within warn window", 20 * 24 * time.Hour, expiryWarn},
-		{"just above error threshold", certExpiryErrorThreshold + time.Hour, expiryWarn},
-		{"at error threshold", certExpiryErrorThreshold, expiryError},
-		{"within error window", 3 * 24 * time.Hour, expiryError},
-		{"already expired", -time.Hour, expiryError},
+		{"token auth, no cert", false, time.Time{}, expiryNone, ""},
+		{"cert present but unparseable expiry", true, time.Time{}, expiryWarn, "Could not determine Apple push certificate expiry"},
+		{"plenty of validity", true, now.Add(90 * 24 * time.Hour), expiryNone, ""},
+		{"just above warn threshold", true, now.Add(certExpiryWarnThreshold + time.Hour), expiryNone, ""},
+		{"at warn threshold", true, now.Add(certExpiryWarnThreshold), expiryWarn, "Apple push certificate is expiring soon"},
+		{"within warn window", true, now.Add(20 * 24 * time.Hour), expiryWarn, "Apple push certificate is expiring soon"},
+		{"just above error threshold", true, now.Add(certExpiryErrorThreshold + time.Hour), expiryWarn, "Apple push certificate is expiring soon"},
+		{"at error threshold", true, now.Add(certExpiryErrorThreshold), expiryError, "Apple push certificate is expiring soon"},
+		{"within error window", true, now.Add(3 * 24 * time.Hour), expiryError, "Apple push certificate is expiring soon"},
+		{"already expired", true, now.Add(-time.Hour), expiryError, "Apple push certificate has expired"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, certExpiryStatus(tc.timeLeft))
+			level, message := certExpiryReport(tc.hasCert, tc.notAfter, now)
+			assert.Equal(t, tc.wantLevel, level)
+			assert.Equal(t, tc.wantMessage, message)
 		})
 	}
 }

--- a/server/apple_notification_test.go
+++ b/server/apple_notification_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	apns "github.com/sideshow/apns2"
 	"github.com/stretchr/testify/assert"
@@ -237,18 +236,87 @@ func newTestCertDER(t *testing.T, notAfter time.Time) []byte {
 	return der
 }
 
-func TestCheckCredentialExpiryNoCertIsNoop(t *testing.T) {
-	logger, err := mlog.NewLogger()
-	require.NoError(t, err)
+func TestAppleCheckCredentialExpiry(t *testing.T) {
+	t.Run("token auth is a silent no-op", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		srv := &AppleNotificationServer{
+			ApplePushSettings: ApplePushSettings{Type: "apple"},
+			logger:            logger,
+		}
 
-	// Token (AuthKey) auth leaves certNotAfter at its zero value.
-	srv := &AppleNotificationServer{
-		ApplePushSettings: ApplePushSettings{Type: "apple"},
-		logger:            logger,
-	}
+		srv.checkCredentialExpiry()
 
-	assert.True(t, srv.certNotAfter.IsZero())
-	assert.NotPanics(t, srv.checkCredentialExpiry)
+		assert.False(t, srv.hasCert)
+		assert.Empty(t, flushLogs(t, logger, buf))
+	})
+
+	t.Run("warns when a certificate expiry cannot be parsed", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		srv := &AppleNotificationServer{
+			ApplePushSettings: ApplePushSettings{Type: "apple"},
+			logger:            logger,
+			hasCert:           true,
+		}
+
+		srv.checkCredentialExpiry()
+
+		records := flushLogs(t, logger, buf)
+		require.Len(t, records, 1)
+		assert.Equal(t, "warn", records[0]["level"])
+		assert.Contains(t, records[0]["msg"], "Could not determine")
+		_, hasExpiry := records[0]["expires_at"]
+		assert.False(t, hasExpiry, "no expiry fields when expiry is unknown")
+	})
+
+	t.Run("warns within the warning window", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		srv := &AppleNotificationServer{
+			ApplePushSettings: ApplePushSettings{Type: "apple"},
+			logger:            logger,
+			hasCert:           true,
+			certNotAfter:      time.Now().Add(20 * 24 * time.Hour),
+		}
+
+		srv.checkCredentialExpiry()
+
+		records := flushLogs(t, logger, buf)
+		require.Len(t, records, 1)
+		assert.Equal(t, "warn", records[0]["level"])
+		assert.Contains(t, records[0]["msg"], "expiring soon")
+		assert.Contains(t, records[0], "expires_at")
+		assert.Contains(t, records[0], "time_left")
+	})
+
+	t.Run("errors once expired", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		srv := &AppleNotificationServer{
+			ApplePushSettings: ApplePushSettings{Type: "apple"},
+			logger:            logger,
+			hasCert:           true,
+			certNotAfter:      time.Now().Add(-time.Hour),
+		}
+
+		srv.checkCredentialExpiry()
+
+		records := flushLogs(t, logger, buf)
+		require.Len(t, records, 1)
+		assert.Equal(t, "error", records[0]["level"])
+		assert.Contains(t, records[0]["msg"], "has expired")
+	})
+
+	t.Run("stays silent with plenty of validity", func(t *testing.T) {
+		logger, buf := newCapturingLogger(t)
+		srv := &AppleNotificationServer{
+			ApplePushSettings: ApplePushSettings{Type: "apple"},
+			logger:            logger,
+			hasCert:           true,
+			certNotAfter:      time.Now().Add(90 * 24 * time.Hour),
+		}
+
+		srv.checkCredentialExpiry()
+
+		assert.Empty(t, flushLogs(t, logger, buf))
+	})
 }
 
 func marshalPayload(t *testing.T, n *apns.Notification) map[string]any {

--- a/server/config_push_proxy.go
+++ b/server/config_push_proxy.go
@@ -23,6 +23,7 @@ type ConfigPushProxy struct {
 	EnableConsoleLog        bool
 	EnableFileLog           bool
 	LogFormat               string // json or plain
+	LogLevel                string // debug, info (default), warn, or error
 	ThrottlePerSec          int
 	ThrottleMemoryStoreSize int
 }

--- a/server/logger.go
+++ b/server/logger.go
@@ -5,6 +5,8 @@ package server
 
 import (
 	"encoding/json"
+	"strings"
+
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
@@ -27,22 +29,41 @@ func NewLogger(cfg *ConfigPushProxy) (*mlog.Logger, error) {
 
 func buildLogConfig(cfg *ConfigPushProxy) mlog.LoggerConfiguration {
 	logConf := make(mlog.LoggerConfiguration)
+	levels := levelsFor(cfg.LogLevel)
 
 	if cfg.EnableFileLog && cfg.LogFileLocation != "" {
-		logConf["file"] = buildLogFileConfig(cfg.LogFileLocation, cfg.LogFormat)
+		logConf["file"] = buildLogFileConfig(cfg.LogFileLocation, cfg.LogFormat, levels)
 	}
 
 	if cfg.EnableConsoleLog || cfg.LogFileLocation == "" || !cfg.EnableFileLog {
-		logConf["console"] = buildConsoleLogConfig(cfg.LogFormat)
+		logConf["console"] = buildConsoleLogConfig(cfg.LogFormat, levels)
 	}
 
 	return logConf
 }
 
-func buildConsoleLogConfig(format string) mlog.TargetCfg {
+// levelsFor maps the configured log level to the set of levels emitted by the
+// log targets. It always includes Panic/Fatal/Error and LvlStdLog; higher
+// verbosity levels are added as the threshold is lowered. Defaults to "info".
+func levelsFor(level string) []mlog.Level {
+	base := []mlog.Level{mlog.LvlPanic, mlog.LvlFatal, mlog.LvlError, mlog.LvlStdLog}
+
+	switch strings.ToLower(level) {
+	case "error":
+		return base
+	case "warn":
+		return append(base, mlog.LvlWarn)
+	case "debug":
+		return mlog.StdAll
+	default: // "info"
+		return append(base, mlog.LvlWarn, mlog.LvlInfo)
+	}
+}
+
+func buildConsoleLogConfig(format string, levels []mlog.Level) mlog.TargetCfg {
 	return mlog.TargetCfg{
 		Type:          "console",
-		Levels:        mlog.StdAll,
+		Levels:        levels,
 		Format:        format,
 		Options:       json.RawMessage(`{"out": "stdout"}`),
 		FormatOptions: json.RawMessage(`{"enable_color": true, "enable_caller": true}`),
@@ -50,7 +71,7 @@ func buildConsoleLogConfig(format string) mlog.TargetCfg {
 	}
 }
 
-func buildLogFileConfig(filename string, format string) mlog.TargetCfg {
+func buildLogFileConfig(filename string, format string, levels []mlog.Level) mlog.TargetCfg {
 	opts := struct {
 		Filename    string `json:"filename"`
 		Max_size    int    `json:"max_size"`
@@ -68,7 +89,7 @@ func buildLogFileConfig(filename string, format string) mlog.TargetCfg {
 
 	return mlog.TargetCfg{
 		Type:          "file",
-		Levels:        mlog.StdAll,
+		Levels:        levels,
 		Format:        format,
 		Options:       optsJsonString,
 		FormatOptions: json.RawMessage(`{"enable_color": true, "enable_caller": true}`),

--- a/server/logger_test.go
+++ b/server/logger_test.go
@@ -4,10 +4,12 @@
 package server
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMlogLogger(t *testing.T) {
@@ -57,5 +59,64 @@ func TestNewMlogLogger(t *testing.T) {
 		logger, err := NewLogger(cfg)
 		assert.NoError(t, err)
 		assert.NotNil(t, logger)
+	})
+}
+
+func TestLevelsFor(t *testing.T) {
+	contains := func(levels []mlog.Level, target mlog.Level) bool {
+		for _, l := range levels {
+			if l.ID == target.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Panic/Fatal/Error are always emitted regardless of the configured level.
+	for _, level := range []string{"error", "warn", "info", "debug", "", "garbage"} {
+		levels := levelsFor(level)
+		assert.True(t, contains(levels, mlog.LvlError), "%q should always include Error", level)
+		assert.True(t, contains(levels, mlog.LvlFatal), "%q should always include Fatal", level)
+	}
+
+	t.Run("error", func(t *testing.T) {
+		levels := levelsFor("error")
+		assert.False(t, contains(levels, mlog.LvlWarn))
+		assert.False(t, contains(levels, mlog.LvlInfo))
+		assert.False(t, contains(levels, mlog.LvlDebug))
+	})
+
+	t.Run("warn", func(t *testing.T) {
+		levels := levelsFor("warn")
+		assert.True(t, contains(levels, mlog.LvlWarn))
+		assert.False(t, contains(levels, mlog.LvlInfo))
+		assert.False(t, contains(levels, mlog.LvlDebug))
+	})
+
+	t.Run("info excludes debug and trace", func(t *testing.T) {
+		levels := levelsFor("info")
+		assert.True(t, contains(levels, mlog.LvlWarn))
+		assert.True(t, contains(levels, mlog.LvlInfo))
+		assert.False(t, contains(levels, mlog.LvlDebug))
+		assert.False(t, contains(levels, mlog.LvlTrace))
+	})
+
+	t.Run("unknown and empty default to info", func(t *testing.T) {
+		for _, level := range []string{"", "garbage"} {
+			levels := levelsFor(level)
+			assert.True(t, contains(levels, mlog.LvlInfo), "%q should include Info", level)
+			assert.False(t, contains(levels, mlog.LvlDebug), "%q should not include Debug", level)
+		}
+	})
+
+	t.Run("debug includes debug and trace", func(t *testing.T) {
+		levels := levelsFor("debug")
+		assert.True(t, contains(levels, mlog.LvlDebug))
+		assert.True(t, contains(levels, mlog.LvlTrace))
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		levels := levelsFor("DEBUG")
+		assert.True(t, contains(levels, mlog.LvlDebug))
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -147,10 +147,11 @@ func (s *Server) Start() {
 
 // credentialCheckInterval controls how often push-target credentials are
 // re-checked for upcoming expiry, so long-running processes still alert.
-const credentialCheckInterval = time.Hour
+const credentialCheckInterval = 12 * time.Hour
 
-// watchCredentialExpiry checks push-target credentials at startup and hourly
-// thereafter, letting targets log a Warn/Error as expiry approaches.
+// watchCredentialExpiry checks push-target credentials at startup and every
+// credentialCheckInterval thereafter, letting targets log a Warn/Error as
+// expiry approaches.
 func (s *Server) watchCredentialExpiry() {
 	defer s.bgWorkers.Done()
 

--- a/server/server.go
+++ b/server/server.go
@@ -140,9 +140,8 @@ func (s *Server) Start() {
 	s.logger.Info("Server is listening on " + s.cfg.ListenAddress)
 
 	s.statsDone = make(chan struct{})
-	s.bgWorkers.Add(2)
-	go s.reportStats()
-	go s.watchCredentialExpiry()
+	s.bgWorkers.Go(s.reportStats)
+	s.bgWorkers.Go(s.watchCredentialExpiry)
 }
 
 // credentialCheckInterval controls how often push-target credentials are
@@ -153,8 +152,6 @@ const credentialCheckInterval = 12 * time.Hour
 // credentialCheckInterval thereafter, letting targets log a Warn/Error as
 // expiry approaches.
 func (s *Server) watchCredentialExpiry() {
-	defer s.bgWorkers.Done()
-
 	s.checkCredentialExpiry()
 
 	ticker := time.NewTicker(credentialCheckInterval)
@@ -182,8 +179,6 @@ func (s *Server) checkCredentialExpiry() {
 // statsReportInterval, giving a low-volume operational heartbeat in place of
 // per-notification logging.
 func (s *Server) reportStats() {
-	defer s.bgWorkers.Done()
-
 	ticker := time.NewTicker(statsReportInterval)
 	defer ticker.Stop()
 
@@ -224,6 +219,7 @@ func (s *Server) Stop() {
 		// final throughput flush completes before the logger is shut down.
 		close(s.statsDone)
 		s.bgWorkers.Wait()
+		s.statsDone = nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), WAIT_FOR_SERVER_SHUTDOWN)
 	defer cancel()

--- a/server/server.go
+++ b/server/server.go
@@ -144,9 +144,9 @@ func (s *Server) Start() {
 
 // credentialCheckInterval controls how often push-target credentials are
 // re-checked for upcoming expiry, so long-running processes still alert.
-const credentialCheckInterval = 24 * time.Hour
+const credentialCheckInterval = time.Hour
 
-// watchCredentialExpiry checks push-target credentials at startup and daily
+// watchCredentialExpiry checks push-target credentials at startup and hourly
 // thereafter, letting targets log a Warn/Error as expiry approaches.
 func (s *Server) watchCredentialExpiry() {
 	s.checkCredentialExpiry()

--- a/server/server.go
+++ b/server/server.go
@@ -139,6 +139,37 @@ func (s *Server) Start() {
 
 	s.statsDone = make(chan struct{})
 	go s.reportStats()
+	go s.watchCredentialExpiry()
+}
+
+// credentialCheckInterval controls how often push-target credentials are
+// re-checked for upcoming expiry, so long-running processes still alert.
+const credentialCheckInterval = 24 * time.Hour
+
+// watchCredentialExpiry checks push-target credentials at startup and daily
+// thereafter, letting targets log a Warn/Error as expiry approaches.
+func (s *Server) watchCredentialExpiry() {
+	s.checkCredentialExpiry()
+
+	ticker := time.NewTicker(credentialCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.statsDone:
+			return
+		case <-ticker.C:
+			s.checkCredentialExpiry()
+		}
+	}
+}
+
+func (s *Server) checkCredentialExpiry() {
+	for _, target := range s.pushTargets {
+		if c, ok := target.(interface{ checkCredentialExpiry() }); ok {
+			c.checkCredentialExpiry()
+		}
+	}
 }
 
 // reportStats logs aggregated send/ack throughput once per

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/handlers"
@@ -46,6 +47,7 @@ type Server struct {
 	logger      *mlog.Logger
 	stats       *stats
 	statsDone   chan struct{}
+	bgWorkers   sync.WaitGroup
 }
 
 // New returns a new Server instance.
@@ -138,6 +140,7 @@ func (s *Server) Start() {
 	s.logger.Info("Server is listening on " + s.cfg.ListenAddress)
 
 	s.statsDone = make(chan struct{})
+	s.bgWorkers.Add(2)
 	go s.reportStats()
 	go s.watchCredentialExpiry()
 }
@@ -149,6 +152,8 @@ const credentialCheckInterval = time.Hour
 // watchCredentialExpiry checks push-target credentials at startup and hourly
 // thereafter, letting targets log a Warn/Error as expiry approaches.
 func (s *Server) watchCredentialExpiry() {
+	defer s.bgWorkers.Done()
+
 	s.checkCredentialExpiry()
 
 	ticker := time.NewTicker(credentialCheckInterval)
@@ -176,6 +181,8 @@ func (s *Server) checkCredentialExpiry() {
 // statsReportInterval, giving a low-volume operational heartbeat in place of
 // per-notification logging.
 func (s *Server) reportStats() {
+	defer s.bgWorkers.Done()
+
 	ticker := time.NewTicker(statsReportInterval)
 	defer ticker.Stop()
 
@@ -212,7 +219,10 @@ func (s *Server) logThroughput() {
 func (s *Server) Stop() {
 	s.logger.Info("Stopping Server...")
 	if s.statsDone != nil {
+		// Signal the background workers and wait for them to finish so the
+		// final throughput flush completes before the logger is shut down.
 		close(s.statsDone)
+		s.bgWorkers.Wait()
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), WAIT_FOR_SERVER_SHUTDOWN)
 	defer cancel()

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,8 @@ type Server struct {
 	pushTargets map[string]NotificationServer
 	metrics     *metrics
 	logger      *mlog.Logger
+	stats       *stats
+	statsDone   chan struct{}
 }
 
 // New returns a new Server instance.
@@ -52,6 +54,7 @@ func New(cfg *ConfigPushProxy, logger *mlog.Logger) *Server {
 		cfg:         cfg,
 		pushTargets: make(map[string]NotificationServer),
 		logger:      logger,
+		stats:       &stats{},
 	}
 }
 
@@ -72,7 +75,7 @@ func (s *Server) Start() {
 	}
 
 	for _, settings := range s.cfg.ApplePushSettings {
-		server := NewAppleNotificationServer(settings, s.logger, m, s.cfg.SendTimeoutSec, s.cfg.RetryTimeoutSec)
+		server := NewAppleNotificationServer(settings, s.logger, m, s.stats, s.cfg.SendTimeoutSec, s.cfg.RetryTimeoutSec)
 		err := server.Initialize()
 		if err != nil {
 			s.logger.Error("Failed to initialize client", mlog.Err(err))
@@ -82,7 +85,7 @@ func (s *Server) Start() {
 	}
 
 	for _, settings := range s.cfg.AndroidPushSettings {
-		server := NewAndroidNotificationServer(settings, s.logger, m, s.cfg.SendTimeoutSec, s.cfg.RetryTimeoutSec)
+		server := NewAndroidNotificationServer(settings, s.logger, m, s.stats, s.cfg.SendTimeoutSec, s.cfg.RetryTimeoutSec)
 		err := server.Initialize()
 		if err != nil {
 			s.logger.Error("Failed to initialize client", mlog.Err(err))
@@ -98,7 +101,7 @@ func (s *Server) Start() {
 	th := throttled.RateLimit(throttled.PerSec(s.cfg.ThrottlePerSec), &vary, throttledStore.NewMemStore(s.cfg.ThrottleMemoryStoreSize))
 
 	th.DeniedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.logger.Error("Error: code=429", mlog.String("path", r.URL.Path), mlog.String("ip", s.getIpAddress(r)))
+		s.logger.Warn("Request throttled", mlog.Int("code", 429), mlog.String("path", r.URL.Path), mlog.String("ip", s.getIpAddress(r)))
 		throttled.DefaultDeniedHandler.ServeHTTP(w, r)
 	})
 
@@ -133,11 +136,53 @@ func (s *Server) Start() {
 	}()
 
 	s.logger.Info("Server is listening on " + s.cfg.ListenAddress)
+
+	s.statsDone = make(chan struct{})
+	go s.reportStats()
+}
+
+// reportStats logs aggregated send/ack throughput once per
+// statsReportInterval, giving a low-volume operational heartbeat in place of
+// per-notification logging.
+func (s *Server) reportStats() {
+	ticker := time.NewTicker(statsReportInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.statsDone:
+			// Flush the partial final window so no counts are lost on shutdown.
+			s.logThroughput()
+			return
+		case <-ticker.C:
+			s.logThroughput()
+		}
+	}
+}
+
+// logThroughput logs and resets the accumulated counters. Windows with no
+// activity are skipped to keep idle servers quiet.
+func (s *Server) logThroughput() {
+	android, apple, acks := s.stats.swap()
+	if android == 0 && apple == 0 && acks == 0 {
+		return
+	}
+
+	s.logger.Info(
+		"Notification throughput",
+		mlog.Duration("interval", statsReportInterval),
+		mlog.Int("android_sends", android),
+		mlog.Int("apple_sends", apple),
+		mlog.Int("acks", acks),
+	)
 }
 
 // Stop stops the server.
 func (s *Server) Stop() {
 	s.logger.Info("Stopping Server...")
+	if s.statsDone != nil {
+		close(s.statsDone)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), WAIT_FOR_SERVER_SHUTDOWN)
 	defer cancel()
 	if s.metrics != nil {
@@ -159,7 +204,7 @@ func (s *Server) version(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
-		s.logger.Error("Failed to write response", mlog.Err(err))
+		s.logger.Warn("Failed to write response", mlog.Err(err))
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
 		}
@@ -181,10 +226,10 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 	err := json.NewDecoder(r.Body).Decode(&msg)
 	if err != nil {
 		rMsg := fmt.Sprintf("Failed to read message body: %v", err)
-		s.logger.Error(rMsg)
+		s.logger.Warn("Failed to read message body", mlog.Err(err))
 		resp := NewErrorPushResponse(rMsg)
 		if err2 := json.NewEncoder(w).Encode(resp); err2 != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err2))
+			s.logger.Warn("Failed to write response", mlog.Err(err2))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -194,10 +239,10 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 
 	if msg.ServerId == "" {
 		rMsg := "Failed because of missing server Id"
-		s.logger.Error(rMsg)
+		s.logger.Warn("Missing server id")
 		resp := NewErrorPushResponse(rMsg)
 		if err2 := json.NewEncoder(w).Encode(resp); err2 != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err2))
+			s.logger.Warn("Failed to write response", mlog.Err(err2))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -207,10 +252,10 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 
 	if msg.DeviceId == "" {
 		rMsg := fmt.Sprintf("Failed because of missing device Id serverId=%v", msg.ServerId)
-		s.logger.Error(rMsg)
+		s.logger.Warn("Missing device id", mlog.String("server_id", msg.ServerId))
 		resp := NewErrorPushResponse(rMsg)
 		if err2 := json.NewEncoder(w).Encode(resp); err2 != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err2))
+			s.logger.Warn("Failed to write response", mlog.Err(err2))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -236,8 +281,11 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 		if e == nil {
 			appVersion = version
 		} else {
-			rMsg := fmt.Sprintf("Could not determine the app version in %v appVersion=%v", msg.Platform, appVersionString)
-			s.logger.Error(rMsg)
+			s.logger.Warn(
+				"Could not determine app version",
+				mlog.String("platform", msg.Platform),
+				mlog.String("app_version", appVersionString),
+			)
 		}
 	}
 
@@ -247,16 +295,20 @@ func (s *Server) handleSendNotification(w http.ResponseWriter, r *http.Request) 
 		}
 		rMsg := server.SendNotification(appVersion, &msg)
 		if err2 := json.NewEncoder(w).Encode(rMsg); err2 != nil {
-			s.logger.Error("Failed to write message", mlog.Err(err2))
+			s.logger.Warn("Failed to write message", mlog.Err(err2))
 		}
 		return
 	}
 	rMsg := fmt.Sprintf("Did not send message because of missing platform property type=%v serverId=%v", msg.Platform, msg.ServerId)
-	s.logger.Error(rMsg)
+	s.logger.Warn(
+		"No push target for platform",
+		mlog.String("platform", msg.Platform),
+		mlog.String("server_id", msg.ServerId),
+	)
 	resp := NewErrorPushResponse(rMsg)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
-		s.logger.Error("Failed to write response", mlog.Err(err))
+		s.logger.Warn("Failed to write response", mlog.Err(err))
 	}
 	if s.metrics != nil {
 		s.metrics.incrementBadRequest()
@@ -268,10 +320,10 @@ func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&ack)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to read ack body: %v", err)
-		s.logger.Error(msg)
+		s.logger.Warn("Failed to read ack body", mlog.Err(err))
 		resp := NewErrorPushResponse(msg)
 		if err2 := json.NewEncoder(w).Encode(resp); err2 != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err2))
+			s.logger.Warn("Failed to write response", mlog.Err(err2))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -281,10 +333,10 @@ func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 
 	if ack.Id == "" {
 		msg := "Failed because of missing ack Id"
-		s.logger.Error(msg)
+		s.logger.Warn("Missing ack id")
 		resp := NewErrorPushResponse(msg)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err))
+			s.logger.Warn("Failed to write response", mlog.Err(err))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -294,10 +346,10 @@ func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 
 	if ack.ClientPlatform == "" {
 		msg := "Failed because of missing ack platform"
-		s.logger.Error(msg)
+		s.logger.Warn("Missing ack platform", mlog.String("ack_id", ack.Id))
 		resp := NewErrorPushResponse(msg)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err))
+			s.logger.Warn("Failed to write response", mlog.Err(err))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -307,10 +359,10 @@ func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 
 	if ack.NotificationType == "" {
 		msg := "Failed because of missing ack type"
-		s.logger.Error(msg)
+		s.logger.Warn("Missing ack type", mlog.String("ack_id", ack.Id))
 		resp := NewErrorPushResponse(msg)
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			s.logger.Error("Failed to write response", mlog.Err(err))
+			s.logger.Warn("Failed to write response", mlog.Err(err))
 		}
 		if s.metrics != nil {
 			s.metrics.incrementBadRequest()
@@ -319,14 +371,15 @@ func (s *Server) handleAckNotification(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Increment ACK
-	s.logger.Info("Acknowledged delivery receipt", mlog.String("ack_id", ack.Id))
+	s.stats.incrementAck()
+	s.logger.Debug("Acknowledged delivery receipt", mlog.String("ack_id", ack.Id))
 	if s.metrics != nil {
 		s.metrics.incrementDelivered(ack.ClientPlatform, ack.NotificationType, model.PushTransportStandard)
 	}
 
 	rMsg := NewOkPushResponse()
 	if err := json.NewEncoder(w).Encode(rMsg); err != nil {
-		s.logger.Error("Failed to write message", mlog.Err(err))
+		s.logger.Warn("Failed to write message", mlog.Err(err))
 	}
 }
 
@@ -341,7 +394,7 @@ func (s *Server) getIpAddress(r *http.Request) string {
 	if address == "" {
 		address, _, err = net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
-			s.logger.Error("error in getting IP address", mlog.Err(err))
+			s.logger.Warn("error in getting IP address", mlog.Err(err))
 		}
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -167,6 +167,43 @@ func TestLogThroughput(t *testing.T) {
 	assert.NotPanics(t, srv.logThroughput)
 }
 
+type fakeExpiryTarget struct {
+	calls int
+}
+
+func (f *fakeExpiryTarget) SendNotification(_ int, _ *model.PushNotification) PushResponse {
+	return NewOkPushResponse()
+}
+func (f *fakeExpiryTarget) Initialize() error      { return nil }
+func (f *fakeExpiryTarget) checkCredentialExpiry() { f.calls++ }
+
+// plainTarget implements NotificationServer but not the credential-expiry
+// interface, so it must be skipped by the periodic check.
+type plainTarget struct{}
+
+func (plainTarget) SendNotification(_ int, _ *model.PushNotification) PushResponse {
+	return NewOkPushResponse()
+}
+func (plainTarget) Initialize() error { return nil }
+
+func TestServerCheckCredentialExpiry(t *testing.T) {
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	srv := New(&ConfigPushProxy{}, logger)
+	ft := &fakeExpiryTarget{}
+	srv.pushTargets["apple"] = ft
+	srv.pushTargets["android"] = plainTarget{}
+
+	// Targets that implement checkCredentialExpiry are called; those that
+	// don't are skipped without panicking.
+	assert.NotPanics(t, srv.checkCredentialExpiry)
+	assert.Equal(t, 1, ft.calls)
+
+	srv.checkCredentialExpiry()
+	assert.Equal(t, 2, ft.calls)
+}
+
 func TestServer_version(t *testing.T) {
 	fileName := FindConfigFile("mattermost-push-proxy.sample.json")
 	cfg, err := LoadConfig(fileName)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -122,6 +122,51 @@ func TestAndroidSend(t *testing.T) {
 	time.Sleep(time.Second * 2)
 }
 
+func TestHandleAckNotificationIncrementsStats(t *testing.T) {
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	srv := New(&ConfigPushProxy{}, logger)
+
+	ack := model.PushNotificationAck{
+		Id:               "ack1",
+		ClientPlatform:   model.PushNotifyAndroid,
+		NotificationType: model.PushTypeMessage,
+	}
+	buf, err := json.Marshal(ack)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ack", bytes.NewReader(buf))
+	res := httptest.NewRecorder()
+	srv.handleAckNotification(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+
+	_, _, acks := srv.stats.swap()
+	assert.Equal(t, int64(1), acks)
+}
+
+func TestLogThroughput(t *testing.T) {
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	srv := New(&ConfigPushProxy{}, logger)
+
+	srv.stats.incrementAndroidSend()
+	srv.stats.incrementAppleSend()
+	srv.stats.incrementAck()
+
+	// Emitting the throughput report must consume (reset) the counters.
+	assert.NotPanics(t, srv.logThroughput)
+
+	android, apple, acks := srv.stats.swap()
+	assert.Equal(t, int64(0), android)
+	assert.Equal(t, int64(0), apple)
+	assert.Equal(t, int64(0), acks)
+
+	// A report over an empty window is a safe no-op.
+	assert.NotPanics(t, srv.logThroughput)
+}
+
 func TestServer_version(t *testing.T) {
 	fileName := FindConfigFile("mattermost-push-proxy.sample.json")
 	cfg, err := LoadConfig(fileName)

--- a/server/stats.go
+++ b/server/stats.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// statsReportInterval controls how often aggregated throughput is logged.
+// Per-notification events are logged at Debug; this keeps a low-volume
+// operational heartbeat at Info.
+const statsReportInterval = time.Minute
+
+// stats holds lightweight atomic counters for notification throughput. It is
+// kept independent of the Prometheus metrics so the heartbeat works even when
+// metrics are disabled. All methods are safe to call on a nil receiver.
+type stats struct {
+	androidSends atomic.Int64
+	appleSends   atomic.Int64
+	acks         atomic.Int64
+}
+
+func (s *stats) incrementAndroidSend() {
+	if s == nil {
+		return
+	}
+	s.androidSends.Add(1)
+}
+
+func (s *stats) incrementAppleSend() {
+	if s == nil {
+		return
+	}
+	s.appleSends.Add(1)
+}
+
+func (s *stats) incrementAck() {
+	if s == nil {
+		return
+	}
+	s.acks.Add(1)
+}
+
+// swap atomically reads and resets the counters, returning the totals
+// accumulated since the previous call.
+func (s *stats) swap() (android, apple, acks int64) {
+	return s.androidSends.Swap(0), s.appleSends.Swap(0), s.acks.Swap(0)
+}

--- a/server/stats.go
+++ b/server/stats.go
@@ -46,5 +46,8 @@ func (s *stats) incrementAck() {
 // swap atomically reads and resets the counters, returning the totals
 // accumulated since the previous call.
 func (s *stats) swap() (android, apple, acks int64) {
+	if s == nil {
+		return 0, 0, 0
+	}
 	return s.androidSends.Swap(0), s.appleSends.Swap(0), s.acks.Swap(0)
 }

--- a/server/stats_test.go
+++ b/server/stats_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsIncrementAndSwap(t *testing.T) {
+	s := &stats{}
+
+	s.incrementAndroidSend()
+	s.incrementAndroidSend()
+	s.incrementAppleSend()
+	s.incrementAck()
+	s.incrementAck()
+	s.incrementAck()
+
+	android, apple, acks := s.swap()
+	assert.Equal(t, int64(2), android)
+	assert.Equal(t, int64(1), apple)
+	assert.Equal(t, int64(3), acks)
+
+	// swap must reset the counters back to zero.
+	android, apple, acks = s.swap()
+	assert.Equal(t, int64(0), android)
+	assert.Equal(t, int64(0), apple)
+	assert.Equal(t, int64(0), acks)
+}
+
+func TestStatsNilReceiverIsSafe(t *testing.T) {
+	var s *stats
+
+	assert.NotPanics(t, func() {
+		s.incrementAndroidSend()
+		s.incrementAppleSend()
+		s.incrementAck()
+	})
+}
+
+func TestStatsConcurrentIncrement(t *testing.T) {
+	s := &stats{}
+
+	const goroutines = 50
+	const perGoroutine = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				s.incrementAndroidSend()
+				s.incrementAppleSend()
+				s.incrementAck()
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := int64(goroutines * perGoroutine)
+	android, apple, acks := s.swap()
+	assert.Equal(t, want, android)
+	assert.Equal(t, want, apple)
+	assert.Equal(t, want, acks)
+}

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/stretchr/testify/require"
+)
+
+// newCapturingLogger returns a logger that writes JSON log records into the
+// returned buffer, so tests can assert on emitted levels, messages, and fields.
+func newCapturingLogger(t *testing.T) (*mlog.Logger, *mlog.Buffer) {
+	t.Helper()
+	logger, err := mlog.NewLogger()
+	require.NoError(t, err)
+
+	buf := &mlog.Buffer{}
+	require.NoError(t, mlog.AddWriterTarget(logger, buf, true, mlog.StdAll...))
+
+	return logger, buf
+}
+
+// flushLogs flushes the logger and returns the captured records, one map per
+// emitted log line.
+func flushLogs(t *testing.T, logger *mlog.Logger, buf *mlog.Buffer) []map[string]any {
+	t.Helper()
+	require.NoError(t, logger.Flush())
+
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record))
+		records = append(records, record)
+	}
+	return records
+}


### PR DESCRIPTION
## Summary

Overhauls logging across the push proxy so error-level logs stay actionable, high-volume per-notification logs no longer flood output, and log lines are aggregation-friendly. Also adds credential-expiry/validity alerting for both push platforms.

- **Level correctness:** Reclassified client-driven conditions (bad requests, rate-limit denials, per-retry send failures, config deprecations, and FCM unregistered/sender-ID-mismatch token removals) from `Error` to `Warn`. `Error` is now reserved for operator-actionable server faults; `Fatal` for unrecoverable startup failures.
- **Level gating (new `LogLevel` config):** Added `LogLevel` (`debug` | `info` (default) | `warn` | `error`) that drives which levels the console/file targets emit, replacing the hardcoded `mlog.StdAll`. Panic/Fatal/Error are always emitted. **Behavior change:** previously *all* levels (incl. Debug/Trace) were logged; set `"LogLevel": "debug"` to restore that.
- **Throughput heartbeat:** Per-send and per-ack logs dropped to `Debug`. A new `Notification throughput` line is emitted at `Info` once per minute with android/apple send counts and ack count, backed by lightweight atomic counters (`server/stats.go`) that work even when Prometheus metrics are disabled. The partial final window is flushed on shutdown (workers are awaited in `Stop` so the flush lands before the logger closes); idle windows are skipped.
- **Credential expiry/validity alerting:** Push-target credentials are checked at startup and every 12h thereafter:
  - **Apple certificate:** remaining validity is inspected; logs `Warn` within 30 days of expiry and `Error` within 7 days or once expired (fields `target_type`, `expires_at`, `time_left`).
  - **FCM service account:** the key carries no readable expiry, so it is actively probed by minting an OAuth2 token; rejection (revoked/disabled/deleted key) is logged at `Error`.
  - Apple AuthKey (token) auth has no expiry and is a no-op.
- **Format cleanup:** Bad-request logs converted from `fmt.Sprintf` messages to static messages + structured fields. Standardized field keys across handlers and push targets: `server_id`, `device_id`, `target_type`, `push_type`, `error_code`, `apns_id` (previously an overloaded/ambiguous `type`, plus `sid`/`did` abbreviations). Renamed the misleading `"Error: code=429"` message to `"Request throttled"`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./server/`
- [x] `go test -race ./...` (full suite passes)
- [x] New unit tests:
  - `stats` counters: increment/swap reset, nil-receiver safety (incl. `swap`), concurrent increments
  - `levelsFor` mapping for each level incl. default/unknown and case-insensitivity
  - ack handler increments the ack counter
  - `logThroughput` consumes/resets counters and is a safe no-op on an empty window
  - `certExpiryStatus` thresholds (OK/Warn/Error incl. boundaries and expired)
  - `certNotAfter` extraction (populated leaf, DER-parse fallback, zero when absent)
  - `checkCredentialExpiry` no-op for Apple token auth; Android token-validator wiring (invoked with a bounded context; nil validator is a no-op)
  - server-level `checkCredentialExpiry` dispatch (targets implementing the check are called, others skipped)
- [ ] Manual: run with `LogLevel: "info"` and confirm per-send lines are gone and the minute heartbeat appears; run with `LogLevel: "debug"` to confirm per-send detail returns.
- [ ] Manual: point at a near-expiry Apple cert and confirm the Warn/Error is logged at startup; revoke/disable the FCM key and confirm the Error is logged.

## Notes

- `statsReportInterval` (1 minute), `credentialCheckInterval` (12h), and the 30d/7d Apple expiry thresholds are currently consts; could be made config-driven later if desired.
- The FCM validity probe makes an outbound OAuth2 token request per Android target on each check; it doubles as a credential liveness signal. Transient network/OAuth failures could produce a one-off `Error`, so alert on sustained failures rather than a single occurrence.
- Did not add an explicit `event` field; static messages serve as the de-facto event name. Can add stable event constants as a follow-up if wanted.